### PR TITLE
fix: Add .checkov.yml

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,4 @@
+---
+skip-check:
+  - CKV_DOCKER_2
+  - CKV_DOCKER_3


### PR DESCRIPTION
Silence CKV_DOCKER_3: "Ensure that a user for the container has been created". We don't want to use a non-root user do to use of volumes in local builds.