### PR TITLE
tweak triggers for ci

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -2,7 +2,13 @@
 # Test built docker images by building simple projects inside them
 
 name: dagger
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, closed ]
+  push:
+    branches-ignore:
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,14 @@
 # Run linters
 
 name: Lint
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, closed ]
+  push:
+    branches-ignore:
+      - main
+
 env:
   APPLY_FIXES: none
   APPLY_FIXES_EVENT: pull_request

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,7 +2,13 @@
 # Test built docker images by building simple projects inside them
 
 name: pytest
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, closed ]
+  push:
+    branches-ignore:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
- push to branch with existing pull request should no longer create duplicate workflows / actions for push and pull