### PR TITLE
ci: run ci also when PR is merged to main

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -5,6 +5,9 @@ name: dagger
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ name: Lint
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - main
 
 env:
   APPLY_FIXES: none

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,9 @@ name: pytest
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
The current workflows do not run when stuff gets merged into `main`. This should hopefully fix it.