### PR TITLE
fix(action): use relative paths for blobs in container

### DIFF
--- a/action/recipes/coreboot.go
+++ b/action/recipes/coreboot.go
@@ -155,7 +155,6 @@ func coreboot(ctx context.Context, client *dagger.Client, common *commonOpts, do
 		)
 		// Path to file in container
 		dst := filepath.Join(
-			common.containerWorkDir,
 			filepath.Join("3rdparty/blobs/mainboard", mainboardDir),
 			opts.blobs[blob].destinationFilename,
 		)


### PR DESCRIPTION
- for blobs the build scrips or makefile tries to make them into absolute path by pre-pending current working directory (so far observed only for FSP, but that might be because FSP was the first blob to be included)
- simple solution is to use just relative paths inside the container

... it is always the path ...