### PR TITLE
refactor build system

### DIFF
--- a/action/recipes/config.go
+++ b/action/recipes/config.go
@@ -70,6 +70,11 @@ type Config struct {
 	Edk2 map[string]Edk2Opts `json:"edk2" validate:"dive"`
 }
 
+// FirmwareModule interface
+type FirmwareModule interface {
+	GetDepends() []string
+}
+
 // ===========
 //  Functions
 // ===========

--- a/action/recipes/config.go
+++ b/action/recipes/config.go
@@ -70,6 +70,21 @@ type Config struct {
 	Edk2 map[string]Edk2Opts `json:"edk2" validate:"dive"`
 }
 
+// AllModules method returns slice with all modules
+func (c Config) AllModules() map[string]FirmwareModule {
+	modules := make(map[string]FirmwareModule)
+	for key, value := range c.Coreboot {
+		modules[key] = value
+	}
+	for key, value := range c.Linux {
+		modules[key] = value
+	}
+	for key, value := range c.Edk2 {
+		modules[key] = value
+	}
+	return modules
+}
+
 // FirmwareModule interface
 type FirmwareModule interface {
 	GetDepends() []string

--- a/action/recipes/config.go
+++ b/action/recipes/config.go
@@ -56,19 +56,19 @@ type CommonOpts struct {
 	//   had been previously checked out.
 	RepoPath string `json:"repo_path" validate:"required,dirpath"`
 
-	// Specifies the (relative) paths to directories where are produced files (inside Docker).
-	DockerOutputDirs []string `json:"docker_output_dirs" validate:"dive,dirpath"`
+	// Specifies the (relative) paths to directories where are produced files (inside Container).
+	ContainerOutputDirs []string `json:"docker_output_dirs" validate:"dive,dirpath"`
 
-	// Specifies the (relative) paths to produced files (inside Docker).
-	DockerOutputFiles []string `json:"docker_output_files" validate:"dive,filepath"`
+	// Specifies the (relative) paths to produced files (inside Container).
+	ContainerOutputFiles []string `json:"docker_output_files" validate:"dive,filepath"`
 
 	// Specifies the (relative) path to directory into which place the produced files.
-	//   Directories listed in DockerOutputDirs and files listed in DockerOutputFiles
+	//   Directories listed in ContainerOutputDirs and files listed in ContainerOutputFiles
 	//   will be exported here.
 	// Example:
 	//   Following setting:
-	//     DockerOutputDirs = []string{"Build/"}
-	//     DockerOutputFiles = []string{"coreboot.rom", "defconfig"}
+	//     ContainerOutputDirs = []string{"Build/"}
+	//     ContainerOutputFiles = []string{"coreboot.rom", "defconfig"}
 	//     OutputDir = "myOutput"
 	//   Will result in:
 	//     myOutput/
@@ -85,7 +85,7 @@ func (opts CommonOpts) GetArtifacts() *[]container.Artifacts {
 	var artifacts []container.Artifacts
 
 	// Directories
-	for _, pathDir := range opts.DockerOutputDirs {
+	for _, pathDir := range opts.ContainerOutputDirs {
 		artifacts = append(artifacts, container.Artifacts{
 			ContainerPath: filepath.Join(ContainerWorkDir, pathDir),
 			ContainerDir:  true,
@@ -95,7 +95,7 @@ func (opts CommonOpts) GetArtifacts() *[]container.Artifacts {
 	}
 
 	// Files
-	for _, pathFile := range opts.DockerOutputFiles {
+	for _, pathFile := range opts.ContainerOutputFiles {
 		artifacts = append(artifacts, container.Artifacts{
 			ContainerPath: filepath.Join(ContainerWorkDir, pathFile),
 			ContainerDir:  false,

--- a/action/recipes/coreboot.go
+++ b/action/recipes/coreboot.go
@@ -110,6 +110,11 @@ type CorebootOpts struct {
 
 // ANCHOR_END: CorebootOpts
 
+// GetDepends is used to return list of dependencies
+func (opts CorebootOpts) GetDepends() []string {
+	return opts.Depends
+}
+
 // corebootProcessBlobs is used to fill figure out blobs from provided data.
 func corebootProcessBlobs(opts CorebootBlobs) ([]BlobDef, error) {
 	blobMap := map[string]BlobDef{

--- a/action/recipes/coreboot.go
+++ b/action/recipes/coreboot.go
@@ -115,6 +115,11 @@ func (opts CorebootOpts) GetDepends() []string {
 	return opts.Depends
 }
 
+// GetArtifacts returns list of wanted artifacts from container
+func (opts CorebootOpts) GetArtifacts() *[]container.Artifacts {
+	return opts.CommonOpts.GetArtifacts()
+}
+
 // corebootProcessBlobs is used to fill figure out blobs from provided data.
 func corebootProcessBlobs(opts CorebootBlobs) ([]BlobDef, error) {
 	blobMap := map[string]BlobDef{
@@ -188,8 +193,8 @@ func corebootProcessBlobs(opts CorebootBlobs) ([]BlobDef, error) {
 	return blobs, nil
 }
 
-// coreboot builds coreboot with all blobs and stuff.
-func coreboot(ctx context.Context, client *dagger.Client, opts *CorebootOpts, dockerfileDirectoryPath string, artifacts *[]container.Artifacts) error {
+// buildFirmware builds coreboot with all blobs and stuff
+func (opts CorebootOpts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
 	// Spin up container
 	containerOpts := container.SetupOpts{
 		ContainerURL:      opts.SdkURL,
@@ -311,7 +316,8 @@ func coreboot(ctx context.Context, client *dagger.Client, opts *CorebootOpts, do
 			return fmt.Errorf("coreboot build failed: %w", err)
 		}
 	}
+	log.Print(opts.CommonOpts.GetArtifacts())
 
 	// Extract artifacts
-	return container.GetArtifacts(ctx, myContainer, artifacts)
+	return container.GetArtifacts(ctx, myContainer, opts.CommonOpts.GetArtifacts())
 }

--- a/action/recipes/coreboot_test.go
+++ b/action/recipes/coreboot_test.go
@@ -66,7 +66,7 @@ func TestCoreboot(t *testing.T) {
 	common := CommonOpts{
 		Arch:      "x86",
 		OutputDir: "output",
-		DockerOutputFiles: []string{
+		ContainerOutputFiles: []string{
 			"build/coreboot.rom",
 			"defconfig",
 		},

--- a/action/recipes/edk2.go
+++ b/action/recipes/edk2.go
@@ -75,6 +75,11 @@ type Edk2Opts struct {
 	Edk2Specific `validate:"required"`
 }
 
+// GetDepends is used to return list of dependencies
+func (opts Edk2Opts) GetDepends() []string {
+	return opts.Depends
+}
+
 // edk2 builds edk2
 func edk2(ctx context.Context, client *dagger.Client, opts *Edk2Opts, dockerfileDirectoryPath string, artifacts *[]container.Artifacts) error {
 	envVars := map[string]string{

--- a/action/recipes/edk2.go
+++ b/action/recipes/edk2.go
@@ -24,7 +24,7 @@ type Edk2Specific struct {
 	//     '-a <architecture>'
 	//     '-p <edk2__platform>'
 	//     '-b <edk2__release_type>'
-	//     '-t <GCC version>' (defined as part of docker toolchain, selected by SdkURL)
+	//     '-t <GCC version>' (defined as part of container toolchain, selected by SdkURL)
 	DefconfigPath string `json:"defconfig_path" validate:"filepath"`
 
 	// Specifies the DSC to use when building EDK2
@@ -47,7 +47,7 @@ type Edk2Specific struct {
 // Edk2Specific is used to store data specific to coreboot.
 type Edk2Specific struct {
 	// Specifies which build command to use
-	// GCC version is exposed in the docker container as USE_GCC_VERSION environment variable
+	// GCC version is exposed in the container container as USE_GCC_VERSION environment variable
 	// Examples:
 	//   "source ./edksetup.sh; build -t GCC5 -a IA32 -p UefiPayloadPkg/UefiPayloadPkg.dsc"
 	//   "python UefiPayloadPkg/UniversalPayloadBuild.py"

--- a/action/recipes/edk2.go
+++ b/action/recipes/edk2.go
@@ -80,8 +80,13 @@ func (opts Edk2Opts) GetDepends() []string {
 	return opts.Depends
 }
 
-// edk2 builds edk2
-func edk2(ctx context.Context, client *dagger.Client, opts *Edk2Opts, dockerfileDirectoryPath string, artifacts *[]container.Artifacts) error {
+// GetArtifacts returns list of wanted artifacts from container
+func (opts Edk2Opts) GetArtifacts() *[]container.Artifacts {
+	return opts.CommonOpts.GetArtifacts()
+}
+
+// buildFirmware builds edk2 or Intel FSP
+func (opts Edk2Opts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
 	envVars := map[string]string{
 		"WORKSPACE":      ContainerWorkDir,
 		"EDK_TOOLS_PATH": "/tools/Edk2/BaseTools",
@@ -161,5 +166,5 @@ func edk2(ctx context.Context, client *dagger.Client, opts *Edk2Opts, dockerfile
 	}
 
 	// Extract artifacts
-	return container.GetArtifacts(ctx, myContainer, artifacts)
+	return container.GetArtifacts(ctx, myContainer, opts.GetArtifacts())
 }

--- a/action/recipes/edk2_test.go
+++ b/action/recipes/edk2_test.go
@@ -25,10 +25,10 @@ func TestEdk2(t *testing.T) {
 	defer os.Chdir(pwd) // nolint:errcheck
 
 	// Use "" if you want to test containers from github package registry
-	// Use "../../docker/edk2" if you want to test containers built fresh from Dockerfile
+	// Use "../../container/edk2" if you want to test containers built fresh from Dockerfile
 	dockerfilePath := ""
 	if false {
-		dockerfilePath, err = filepath.Abs("../../docker/edk2")
+		dockerfilePath, err = filepath.Abs("../../container/edk2")
 		assert.NoError(t, err)
 	}
 
@@ -36,7 +36,7 @@ func TestEdk2(t *testing.T) {
 		SdkURL:           "ghcr.io/9elements/firmware-action/edk2-stable202105:main",
 		Arch:             "X64",
 		OutputDir:        "output",
-		DockerOutputDirs: []string{"Build/"},
+		ContainerOutputDirs: []string{"Build/"},
 	}
 
 	testCases := []struct {

--- a/action/recipes/edk2_test.go
+++ b/action/recipes/edk2_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
-	"github.com/9elements/firmware-action/action/container"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,9 +33,10 @@ func TestEdk2(t *testing.T) {
 	}
 
 	common := CommonOpts{
-		SdkURL:    "ghcr.io/9elements/firmware-action/edk2-stable202105:main",
-		Arch:      "X64",
-		OutputDir: "output",
+		SdkURL:           "ghcr.io/9elements/firmware-action/edk2-stable202105:main",
+		Arch:             "X64",
+		OutputDir:        "output",
+		DockerOutputDirs: []string{"Build/"},
 	}
 
 	testCases := []struct {
@@ -105,17 +105,10 @@ func TestEdk2(t *testing.T) {
 			outputPath := filepath.Join(tmpDir, tc.edk2Options.OutputDir)
 			err = os.MkdirAll(outputPath, os.ModePerm)
 			assert.NoError(t, err)
-			artifacts := []container.Artifacts{
-				{
-					ContainerPath: filepath.Join(ContainerWorkDir, "Build"),
-					ContainerDir:  true,
-					HostPath:      outputPath,
-					HostDir:       true,
-				},
-			}
+			tc.edk2Options.OutputDir = outputPath
 
 			// Try to build edk2
-			err = edk2(ctx, client, &tc.edk2Options, dockerfilePath, &artifacts)
+			err = tc.edk2Options.buildFirmware(ctx, client, dockerfilePath)
 			assert.NoError(t, err)
 
 			// Check artifacts

--- a/action/recipes/linux.go
+++ b/action/recipes/linux.go
@@ -43,6 +43,11 @@ type LinuxOpts struct {
 	LinuxSpecific
 }
 
+// GetDepends is used to return list of dependencies
+func (opts LinuxOpts) GetDepends() []string {
+	return opts.Depends
+}
+
 // linux builds linux kernel
 //
 //	docs: https://www.kernel.org/doc/html/latest/kbuild/index.html

--- a/action/recipes/linux.go
+++ b/action/recipes/linux.go
@@ -48,10 +48,15 @@ func (opts LinuxOpts) GetDepends() []string {
 	return opts.Depends
 }
 
-// linux builds linux kernel
+// GetArtifacts returns list of wanted artifacts from container
+func (opts LinuxOpts) GetArtifacts() *[]container.Artifacts {
+	return opts.CommonOpts.GetArtifacts()
+}
+
+// buildFirmware builds linux kernel
 //
 //	docs: https://www.kernel.org/doc/html/latest/kbuild/index.html
-func linux(ctx context.Context, client *dagger.Client, opts *LinuxOpts, dockerfileDirectoryPath string, artifacts *[]container.Artifacts) error {
+func (opts LinuxOpts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
 	// Spin up container
 	containerOpts := container.SetupOpts{
 		ContainerURL:      opts.SdkURL,
@@ -142,5 +147,5 @@ func linux(ctx context.Context, client *dagger.Client, opts *LinuxOpts, dockerfi
 	}
 
 	// Extract artifacts
-	return container.GetArtifacts(ctx, myContainer, artifacts)
+	return container.GetArtifacts(ctx, myContainer, opts.GetArtifacts())
 }

--- a/action/recipes/linux_test.go
+++ b/action/recipes/linux_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
-	"github.com/9elements/firmware-action/action/container"
 	"github.com/9elements/firmware-action/action/filesystem"
 	"github.com/Masterminds/semver"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +39,10 @@ func TestLinux(t *testing.T) {
 	linuxOpts := LinuxOpts{
 		CommonOpts: CommonOpts{
 			OutputDir: "output",
+			DockerOutputFiles: []string{
+				"vmlinux",
+				"defconfig",
+			},
 		},
 		DefconfigPath: "custom_defconfig",
 	}
@@ -145,23 +148,10 @@ func TestLinux(t *testing.T) {
 			outputPath := filepath.Join(tmpDir, myLinuxOpts.OutputDir)
 			err = os.MkdirAll(outputPath, os.ModePerm)
 			assert.NoError(t, err)
-			artifacts := []container.Artifacts{
-				{
-					ContainerPath: filepath.Join(ContainerWorkDir, "vmlinux"),
-					ContainerDir:  false,
-					HostPath:      outputPath,
-					HostDir:       true,
-				},
-				{
-					ContainerPath: filepath.Join(ContainerWorkDir, "defconfig"),
-					ContainerDir:  false,
-					HostPath:      outputPath,
-					HostDir:       true,
-				},
-			}
+			myLinuxOpts.OutputDir = outputPath
 
 			// Try to build linux kernel
-			err = linux(ctx, client, &myLinuxOpts, dockerfilePath, &artifacts)
+			err = myLinuxOpts.buildFirmware(ctx, client, dockerfilePath)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts

--- a/action/recipes/linux_test.go
+++ b/action/recipes/linux_test.go
@@ -29,17 +29,17 @@ func TestLinux(t *testing.T) {
 	defer os.Chdir(pwd) // nolint:errcheck
 
 	// Use "" if you want to test containers from github package registry
-	// Use "../../docker/linux" if you want to test containers built fresh from Dockerfile
+	// Use "../../container/linux" if you want to test containers built fresh from Dockerfile
 	dockerfilePath := ""
 	if false {
-		dockerfilePath, err = filepath.Abs("../../docker/linux")
+		dockerfilePath, err = filepath.Abs("../../container/linux")
 		assert.NoError(t, err)
 	}
 
 	linuxOpts := LinuxOpts{
 		CommonOpts: CommonOpts{
 			OutputDir: "output",
-			DockerOutputFiles: []string{
+			ContainerOutputFiles: []string{
 				"vmlinux",
 				"defconfig",
 			},

--- a/action/recipes/recipes.go
+++ b/action/recipes/recipes.go
@@ -31,31 +31,12 @@ var (
 // ContainerWorkDir specifies directory in container used as work directory
 var ContainerWorkDir = "/workdir"
 
-type firmwareType interface {
-	Dep() []string
-}
-
-// Dep to get dependencies
-func (c CorebootOpts) Dep() []string {
-	return c.Depends
-}
-
-// Dep to get dependencies
-func (c LinuxOpts) Dep() []string {
-	return c.Depends
-}
-
-// Dep to get dependencies
-func (c Edk2Opts) Dep() []string {
-	return c.Depends
-}
-
-func forestAddVertex(forest *dag.DAG, key string, value firmwareType, dependencies [][]string) ([][]string, error) {
+func forestAddVertex(forest *dag.DAG, key string, value FirmwareModule, dependencies [][]string) ([][]string, error) {
 	err := forest.AddVertexByID(key, key)
 	if err != nil {
 		return nil, err
 	}
-	for _, dep := range value.Dep() {
+	for _, dep := range value.GetDepends() {
 		dependencies = append(dependencies, []string{key, dep})
 	}
 	return dependencies, nil

--- a/action/recipes/recipes.go
+++ b/action/recipes/recipes.go
@@ -50,23 +50,7 @@ func Build(ctx context.Context, target string, recursive bool, config Config, ex
 
 	// Create the forest (forest = multiple independent trees)
 	//   Add all items as vertexes into the tree
-	//   There should be better way to do this other than doing 3x the same thing
-	// -- coreboot --
-	for key, value := range config.Coreboot {
-		dependencies, err = forestAddVertex(dependencyForest, key, value, dependencies)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// -- linux --
-	for key, value := range config.Linux {
-		dependencies, err = forestAddVertex(dependencyForest, key, value, dependencies)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// -- edk2 --
-	for key, value := range config.Edk2 {
+	for key, value := range config.AllModules() {
 		dependencies, err = forestAddVertex(dependencyForest, key, value, dependencies)
 		if err != nil {
 			return nil, err

--- a/tests/example_config.json
+++ b/tests/example_config.json
@@ -6,9 +6,9 @@
       "arch": "",
       "repo_path": "my_super_dooper_awesome_coreboot/",
       "defconfig_path": "seabios_defconfig",
-      "output_dir": "output/",
-      "docker_output_dirs": null,
-      "docker_output_files": [
+      "output_dir": "output-coreboot/",
+      "container_output_dirs": null,
+      "container_output_files": [
         "build/coreboot.rom",
         "defconfig"
       ],
@@ -31,9 +31,9 @@
       "arch": "x86_64",
       "repo_path": "linux-${LINUX_VERSION}/",
       "defconfig_path": "ci_defconfig",
-      "output_dir": "output/",
-      "docker_output_dirs": null,
-      "docker_output_files": [
+      "output_dir": "output-linux/",
+      "container_output_dirs": null,
+      "container_output_files": [
         "vmlinux",
         "defconfig"
       ],
@@ -47,11 +47,11 @@
       "arch": "X64",
       "repo_path": "Edk2/",
       "defconfig_path": "edk2_config.cfg",
-      "output_dir": "output/",
-      "docker_output_dirs": [
+      "output_dir": "output-edk2/",
+      "container_output_dirs": [
         "Build/"
       ],
-      "docker_output_files": null,
+      "container_output_files": null,
       "build_command": "source ./edksetup.sh; build -a X64 -p UefiPayloadPkg/UefiPayloadPkg.dsc -b DEBUG -t GCC5"
     }
   }

--- a/tests/example_config.json
+++ b/tests/example_config.json
@@ -7,6 +7,11 @@
       "repo_path": "my_super_dooper_awesome_coreboot/",
       "defconfig_path": "seabios_defconfig",
       "output_dir": "output/",
+      "docker_output_dirs": null,
+      "docker_output_files": [
+        "build/coreboot.rom",
+        "defconfig"
+      ],
       "blobs": {
         "payload_file_path": "",
         "intel_ifd_path": "",
@@ -27,6 +32,11 @@
       "repo_path": "linux-${LINUX_VERSION}/",
       "defconfig_path": "ci_defconfig",
       "output_dir": "output/",
+      "docker_output_dirs": null,
+      "docker_output_files": [
+        "vmlinux",
+        "defconfig"
+      ],
       "gcc_version": ""
     }
   },
@@ -38,6 +48,10 @@
       "repo_path": "Edk2/",
       "defconfig_path": "edk2_config.cfg",
       "output_dir": "output/",
+      "docker_output_dirs": [
+        "Build/"
+      ],
+      "docker_output_files": null,
       "build_command": "source ./edksetup.sh; build -a X64 -p UefiPayloadPkg/UefiPayloadPkg.dsc -b DEBUG -t GCC5"
     }
   }


### PR DESCRIPTION
Cleanup code by using interfaces and add options for outputs.

## Interfaces
I tired not to go all out with use of interfaces, but I think this is reasonable and significantly cleans up the code. I really like that now there are no `if coreboot ... else if linux ...`. Should much more scalable now.

## Options for outputs
fixes #100 

In essence, until now the files / directories that were extracted out of container after successful build were hard-coded. Now user can configure them! This greatly increases the flexibility.

This was also needed to get Intel FSP fully working. Previous PR #95 allows to build Intel FSP, but to actually get compiled stuff out, this feature is needed.