### PR TITLE
fix(docker): missing ifdtool and cbfstool in container

### DIFF
--- a/docker/coreboot/Dockerfile
+++ b/docker/coreboot/Dockerfile
@@ -82,4 +82,5 @@ RUN echo "${XGCCPATH}"
 # Copy over things from previous stage(s)
 COPY --from=toolchain $XGCCPATH/.. $XGCCPATH/..
 COPY --from=toolchain $TOOLSDIR/MEAnalyzer $TOOLSDIR/
+COPY --from=toolchain /usr/local/bin/* /usr/local/bin/
 


### PR DESCRIPTION
`ifdtool` and `cbfstool` are compiled in `toolchain` stage, but are not copied over to `final` stage.