### PR TITLE
make containers interactive

### DIFF
--- a/action/container/ssh.go
+++ b/action/container/ssh.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+
+// Package container for dealing with containers via dagger
+package container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"strings"
+	"sync"
+
+	"dagger.io/dagger"
+)
+
+// ErrParseAddress is raised when containers IP address could not be parsed
+var ErrParseAddress = errors.New("could not parse address string")
+
+// OptsOpenSSH stores options for SSH tunnel for OpenSSH function
+type OptsOpenSSH struct {
+	WaitFunc  func()      // Waiting function holding container with SSH running
+	Password  string      // Filled in by OpenSSH function
+	IPv4      string      // Filled in by OpenSSH function
+	Port      string      // Filled in by OpenSSH function
+	MutexData *sync.Mutex // Mutex for modifying data in this struct
+
+	// We could do with single channel here, but for clarity and less mental overhead there are 2
+	TunnelClose chan (bool) // Channel to signal that SSH tunnel is ready
+	TunnelReady chan (bool) // Channel to signal that SSH tunnel is not longer needed and can be closed
+}
+
+// Wait calls WaitFunc
+func (s OptsOpenSSH) Wait() {
+	s.WaitFunc()
+}
+
+// Address function parses provided string and populates IPv4 and Port (port defaults to 22 if not found)
+func (s *OptsOpenSSH) Address(address string) error {
+	s.MutexData.Lock()
+	var err error
+
+	sshAddressSplit := strings.Split(address, ":")
+	switch len(sshAddressSplit) {
+	case 1:
+		// IP address but no port
+		s.IPv4 = sshAddressSplit[0]
+		s.Port = "22"
+	case 2:
+		// Possibly both IP address and port
+		s.IPv4 = sshAddressSplit[0]
+		if s.IPv4 == "" {
+			err = fmt.Errorf("%w: '%s'", ErrParseAddress, address)
+		}
+		s.Port = sshAddressSplit[1]
+		if s.Port == "" {
+			s.Port = "22"
+		}
+	default:
+		err = fmt.Errorf("%w: '%s'", ErrParseAddress, address)
+	}
+
+	s.MutexData.Unlock()
+	return err
+}
+
+// SettingsSSH is for functional option pattern
+type SettingsSSH func(*OptsOpenSSH)
+
+// WithWaitPressEnter is one possible function to pass into OpenSSH
+// It will wait until user presses ENTER key to shutdown the container
+func WithWaitPressEnter() SettingsSSH {
+	return func(s *OptsOpenSSH) {
+		s.WaitFunc = func() {
+			<-s.TunnelReady
+			fmt.Print("Press ENTER to stop container ")
+			fmt.Scanln()
+			s.TunnelClose <- true
+		}
+	}
+}
+
+// WithWaitNone is one possible function to pass into OpenSSH
+// It will not wait
+func WithWaitNone() SettingsSSH {
+	return func(s *OptsOpenSSH) {
+		s.WaitFunc = func() {
+			fmt.Println("Skipping waiting")
+		}
+	}
+}
+
+// NewSettingsSSH returns a SettingsSSH
+func NewSettingsSSH(opts ...SettingsSSH) *OptsOpenSSH {
+	// Defaults
+	var m sync.Mutex
+	s := &OptsOpenSSH{
+		MutexData:   &m,
+		TunnelClose: make(chan (bool)),
+		TunnelReady: make(chan (bool)),
+	}
+	WithWaitPressEnter()(s)
+
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// OpenSSH takes a container and starts SSH server with port exposed to the host
+func OpenSSH(
+	ctx context.Context,
+	client *dagger.Client,
+	container *dagger.Container,
+	workdir string,
+	opts *OptsOpenSSH,
+) error {
+	// Example in docs:
+	//   https://docs.dagger.io/cookbook/#expose-service-containers-to-host
+	// This feature is untested and instead relies on tears, blood and sweat produced during
+	//   it's development to work.
+	// UPDATE: After more tears, blood and sweat we also have some testing! Yippee!
+
+	if container == nil {
+		log.Println("skipping SSH because no container was given")
+		return nil
+	}
+
+	if workdir == "" {
+		workdir = "/"
+	}
+
+	// Generate a password for the root user
+	opts.MutexData.Lock()
+	opts.Password = generatePassword(16)
+	opts.MutexData.Unlock()
+
+	// Prepare the container
+	container = container.
+		WithExec([]string{"bash", "-c", fmt.Sprintf("echo 'root:%s' | chpasswd", opts.Password)}).
+		WithExec([]string{"bash", "-c", fmt.Sprintf("echo 'cd %s' >> /root/.bashrc", workdir)}).
+		WithExec([]string{"/usr/sbin/sshd", "-D"})
+
+	// Convert container to service with exposed SSH port
+	const sshPort = 22
+	sshServiceDoc := container.WithExposedPort(sshPort).AsService()
+
+	// Expose the SSH server to the host
+	sshServiceTunnel, err := client.Host().Tunnel(sshServiceDoc).Start(ctx)
+	if err != nil {
+		fmt.Println("Problem getting tunnel up")
+		return err
+	}
+	defer sshServiceTunnel.Stop(ctx) // nolint:errcheck
+
+	// Get and print instructions on how to connect
+	sshAddress, err := sshServiceTunnel.Endpoint(ctx)
+	errAddr := opts.Address(sshAddress)
+	if err != nil || errAddr != nil {
+		fmt.Println("problem getting address")
+		return errors.Join(err, errAddr)
+	}
+	fmt.Printf("Connect into the container with:\n  ssh root@%s -p %s -o PreferredAuthentications=password\n", opts.IPv4, opts.Port)
+	fmt.Printf("Password is:\n  %s\n", opts.Password)
+	fmt.Println("SSH up and running")
+
+	// Wait for user to press key
+	go opts.Wait()
+	opts.TunnelReady <- true
+	<-opts.TunnelClose
+
+	fmt.Println("DONE")
+	return nil
+}
+
+func generatePassword(length int) string {
+	// I suppose we could use crypto/rand, but this seems simpler
+	// Also, it is meant only as temporary password for a temporary container which gets
+	//   shut-down / removed afterwards. I think it is good enough.
+	characters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	pass := make([]rune, length)
+	for i := range pass {
+		pass[i] = characters[rand.Intn(len(characters))]
+	}
+	return string(pass)
+}

--- a/action/container/ssh_test.go
+++ b/action/container/ssh_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+
+// Package container
+package container
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestAddress(t *testing.T) {
+	defaultIPv4 := "192.168.0.1"
+	defaultPort := "22"
+
+	testCases := []struct {
+		name    string
+		address string
+		ipv4    string
+		port    string
+		wantErr error
+	}{
+		{
+			name:    "classic",
+			address: fmt.Sprintf("%s:%s", defaultIPv4, defaultPort),
+			ipv4:    defaultIPv4,
+			port:    defaultPort,
+			wantErr: nil,
+		},
+		{
+			name:    "no port",
+			address: defaultIPv4,
+			ipv4:    defaultIPv4,
+			port:    defaultPort,
+			wantErr: nil,
+		},
+		{
+			name:    "no port but with colon",
+			address: fmt.Sprintf("%s:", defaultIPv4),
+			ipv4:    defaultIPv4,
+			port:    defaultPort,
+			wantErr: nil,
+		},
+		{
+			name:    "no IP but port",
+			address: fmt.Sprintf(":%s", defaultPort),
+			ipv4:    defaultIPv4,
+			port:    defaultPort,
+			wantErr: ErrParseAddress,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := NewSettingsSSH()
+			err := opts.Address(tc.address)
+			assert.ErrorIs(t, err, tc.wantErr)
+			if err != nil {
+				// no need to check if errored
+				return
+			}
+			assert.Equal(t, tc.ipv4, opts.IPv4)
+			assert.Equal(t, tc.port, opts.Port)
+		})
+	}
+}
+
+func TestOpenSSH(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	assert.NoError(t, err)
+	defer client.Close()
+
+	testCases := []struct {
+		name    string
+		opts    SetupOpts
+		optsSSH *OptsOpenSSH
+	}{
+		{
+			name: "hello world",
+			opts: SetupOpts{
+				ContainerURL:      "ghcr.io/9elements/firmware-action/linux_6.1.45:main",
+				MountContainerDir: "/src",
+				MountHostDir:      ".",
+				WorkdirContainer:  "/src",
+			},
+			optsSSH: NewSettingsSSH(WithWaitNone()),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myContainer, err := Setup(ctx, client, &tc.opts, "")
+			assert.NoError(t, err)
+
+			// Open the SSH
+			go func() {
+				err := OpenSSH(ctx, client, myContainer, tc.opts.WorkdirContainer, tc.optsSSH)
+				if err != nil {
+					tc.optsSSH.TunnelClose <- true
+				}
+				assert.NoError(t, err)
+			}()
+			// Wait until SSH server is ready
+			<-tc.optsSSH.TunnelReady
+
+			// Connect with client
+			config := &ssh.ClientConfig{
+				User: "root",
+				Auth: []ssh.AuthMethod{
+					ssh.Password(tc.optsSSH.Password),
+				},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			}
+			client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%s", tc.optsSSH.IPv4, tc.optsSSH.Port), config)
+			assert.NoError(t, err)
+			defer client.Close()
+
+			// Open session
+			session, err := client.NewSession()
+			assert.NoError(t, err)
+			defer session.Close()
+
+			// Run simple command to test functionality
+			var b bytes.Buffer
+			session.Stdout = &b
+			err = session.Run("/usr/bin/whoami")
+			assert.NoError(t, err)
+			assert.Equal(t, "root\n", b.String())
+
+			tc.optsSSH.TunnelClose <- true
+		})
+	}
+}

--- a/action/main.go
+++ b/action/main.go
@@ -30,8 +30,9 @@ var CLI struct {
 	Config string `type:"path" required:"" default:"${config_file}" help:"Path to configuration file"`
 
 	Build struct {
-		Target    string `required:"" help:"Select which target to build, use ID from configuration file"`
-		Recursive bool   `help:"Build recursively with all dependencies and payloads"`
+		Target      string `required:"" help:"Select which target to build, use ID from configuration file"`
+		Recursive   bool   `help:"Build recursively with all dependencies and payloads"`
+		Interactive bool   `help:"Open interactive SSH into container if build fails"`
 	} `cmd:"build" help:"Build a target defined in configuration file."`
 
 	GenerateConfig struct{} `cmd:"generate-config" help:"Generate empty configuration file."`
@@ -42,7 +43,13 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("Inputs:\nConfig:    %s\nTarget:    %s\nRecursive: %t\n", CLI.Config, CLI.Build.Target, CLI.Build.Recursive)
+	log.Printf(
+		"Inputs:\nConfig:    %s\nTarget:    %s\nRecursive: %t\nInteractive: %t\n",
+		CLI.Config,
+		CLI.Build.Target,
+		CLI.Build.Recursive,
+		CLI.Build.Interactive,
+	)
 
 	// Parse configuration file
 	var myConfig recipes.Config
@@ -52,7 +59,14 @@ func run(ctx context.Context) error {
 	}
 
 	// Lets build stuff
-	_, err = recipes.Build(ctx, CLI.Build.Target, CLI.Build.Recursive, myConfig, recipes.Execute)
+	_, err = recipes.Build(
+		ctx,
+		CLI.Build.Target,
+		CLI.Build.Recursive,
+		CLI.Build.Interactive,
+		myConfig,
+		recipes.Execute,
+	)
 	return err
 }
 

--- a/action/recipes/config.go
+++ b/action/recipes/config.go
@@ -130,7 +130,7 @@ func (c Config) AllModules() map[string]FirmwareModule {
 type FirmwareModule interface {
 	GetDepends() []string
 	GetArtifacts() *[]container.Artifacts
-	buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error
+	buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) (*dagger.Container, error)
 }
 
 // ===========

--- a/action/recipes/coreboot_test.go
+++ b/action/recipes/coreboot_test.go
@@ -162,7 +162,7 @@ func TestCoreboot(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			// Try to build coreboot
-			err = tc.corebootOptions.buildFirmware(ctx, client, "")
+			_, err = tc.corebootOptions.buildFirmware(ctx, client, "")
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts

--- a/action/recipes/edk2_test.go
+++ b/action/recipes/edk2_test.go
@@ -107,7 +107,7 @@ func TestEdk2(t *testing.T) {
 			tc.edk2Options.OutputDir = outputPath
 
 			// Try to build edk2
-			err = tc.edk2Options.buildFirmware(ctx, client, dockerfilePath)
+			_, err = tc.edk2Options.buildFirmware(ctx, client, dockerfilePath)
 			assert.NoError(t, err)
 
 			// Check artifacts

--- a/action/recipes/linux_test.go
+++ b/action/recipes/linux_test.go
@@ -151,7 +151,7 @@ func TestLinux(t *testing.T) {
 			myLinuxOpts.OutputDir = outputPath
 
 			// Try to build linux kernel
-			err = myLinuxOpts.buildFirmware(ctx, client, dockerfilePath)
+			_, err = myLinuxOpts.buildFirmware(ctx, client, dockerfilePath)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts

--- a/action/recipes/recipes_test.go
+++ b/action/recipes/recipes_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestExecute(t *testing.T) {
+	const interactive = false
 	ctx := context.Background()
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	assert.NoError(t, err)
@@ -38,13 +39,13 @@ func TestExecute(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err = Execute(ctx, tc.target, tc.config)
+			err = Execute(ctx, tc.target, tc.config, interactive)
 			assert.ErrorIs(t, err, tc.wantErr)
 		})
 	}
 }
 
-func executeDummy(_ context.Context, _ string, _ Config) error {
+func executeDummy(_ context.Context, _ string, _ Config, _ bool) error {
 	return nil
 }
 
@@ -150,15 +151,31 @@ func TestBuild(t *testing.T) {
 			config:    testConfigDependencyHell,
 		},
 	}
+
+	const interactive = false
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := Build(ctx, tc.target, tc.recursive, tc.config, executeDummy)
+			_, err := Build(
+				ctx,
+				tc.target,
+				tc.recursive,
+				interactive,
+				tc.config,
+				executeDummy,
+			)
 			assert.ErrorIs(t, err, tc.wantErr)
 		})
 	}
-
+	const recursive = true
 	t.Run("recursive", func(t *testing.T) {
-		builds, err := Build(ctx, "pizza", true, testConfigDependencyHell, executeDummy)
+		builds, err := Build(
+			ctx,
+			"pizza",
+			recursive,
+			interactive,
+			testConfigDependencyHell,
+			executeDummy,
+		)
 		assert.ErrorIs(t, err, nil)
 
 		// Check for length

--- a/action/recipes/stitching_test.go
+++ b/action/recipes/stitching_test.go
@@ -253,7 +253,7 @@ func TestStitching(t *testing.T) {
 			assert.NoError(t, err)
 			defer client.Close()
 
-			err = tc.stitchingOpts.buildFirmware(ctx, client, "")
+			_, err = tc.stitchingOpts.buildFirmware(ctx, client, "")
 			assert.ErrorIs(t, err, tc.wantErr)
 			if tc.wantErr != nil {
 				return


### PR DESCRIPTION
- on build failure open ssh server in the container and let user connect into it to debug the problem
- to enable this feature user has to pass argument `--interactive`
- into the containers add few editors (nano, vim), tools and utilities people would expect
- ssh login is with password, which is randomly generated

Fixes #109 

Testing will be pain, but I think there needs to be some. So I will take a look at it.