### PR TITLE
Dependabot/update dagger

### DIFF
--- a/.dagger-ci/daggerci/requirements.txt
+++ b/.dagger-ci/daggerci/requirements.txt
@@ -1,5 +1,5 @@
 anyio~=4.3
-dagger-io~=0.9
+dagger-io~=0.10
 prettytable~=3.10
 pytest~=8.0
 pytest-benchmark~=4.0

--- a/action/go.mod
+++ b/action/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.3
 
 require (
-	dagger.io/dagger v0.9.11
+	dagger.io/dagger v0.10.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.8.1
 	github.com/dustin/go-humanize v1.0.1

--- a/action/go.sum
+++ b/action/go.sum
@@ -1,5 +1,5 @@
-dagger.io/dagger v0.9.11 h1:jyfqKKzkQHIzJHIaQRJ9C/rA7LSloRB1MRUJkm5J1bU=
-dagger.io/dagger v0.9.11/go.mod h1:aq9P87v4apEOXKPXzn35uK+by5dUplSU5ZeXm+E8Sgw=
+dagger.io/dagger v0.10.0 h1:iRzQLVOe89rZQwfpcKq8kZLBLXU50uiDti7txZjcl6A=
+dagger.io/dagger v0.10.0/go.mod h1:aq9P87v4apEOXKPXzn35uK+by5dUplSU5ZeXm+E8Sgw=
 github.com/99designs/gqlgen v0.17.42 h1:BVWDOb2VVHQC5k3m6oa0XhDnxltLLrU4so7x/u39Zu4=
 github.com/99designs/gqlgen v0.17.42/go.mod h1:GQ6SyMhwFbgHR0a8r2Wn8fYgEwPxxmndLFPhU63+cJE=
 github.com/Khan/genqlient v0.6.0 h1:Bwb1170ekuNIVIwTJEqvO8y7RxBxXu639VJOkKSrwAk=


### PR DESCRIPTION
Just to be save, I have merged #151 and #152 into single PR and temporarily enabled Dagger builds to actually test the changes.

Dagger changed from 0.9.11 to 0.10.0, wanted to test the changes just to be on save side, because I have some issues on my local machine. Probably caused by obsolete [dagger package in Arch Linux](https://archlinux.org/packages/extra/x86_64/dagger/) (I flagged it as out-of-date).