### PR TITLE
add coreboot 24.02 example

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coreboot-version: ['4.19', '4.20.1', '4.21']
+        coreboot-version: ['4.19', '4.20.1', '4.21', '24.02']
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Will keep failing until a new container for this coreboot is published (wait until #154 is merged).