### PR TITLE
ci(workflows): change go version in linting to stable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: stable
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4


### PR DESCRIPTION
Somehow this little thing sneaked in and remained there for a long time.