### PR TITLE
refactor logging pt2

### DIFF
--- a/action/recipes/edk2.go
+++ b/action/recipes/edk2.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	"dagger.io/dagger"
@@ -111,7 +111,10 @@ func (opts Edk2Opts) buildFirmware(ctx context.Context, client *dagger.Client, d
 
 	myContainer, err := container.Setup(ctx, client, &containerOpts, dockerfileDirectoryPath)
 	if err != nil {
-		log.Print("Failed to start a container")
+		slog.Error(
+			"Failed to start a container",
+			slog.Any("error", err),
+		)
 		return nil, err
 	}
 
@@ -155,7 +158,11 @@ func (opts Edk2Opts) buildFirmware(ctx context.Context, client *dagger.Client, d
 				return nil, err
 			}
 		} else {
-			log.Printf("Failed to read file '%s' as defconfig_path: file does not exist", opts.DefconfigPath)
+			slog.Warn(
+				fmt.Sprintf("Failed to read file '%s' as defconfig_path: file does not exist", opts.DefconfigPath),
+				slog.String("suggestion", "Double check the path for defconfig"),
+				slog.Any("error", err),
+			)
 		}
 	}
 
@@ -173,7 +180,10 @@ func (opts Edk2Opts) buildFirmware(ctx context.Context, client *dagger.Client, d
 			WithExec(buildSteps[step]).
 			Sync(ctx)
 		if err != nil {
-			log.Print("Failed building of edk2")
+			slog.Error(
+				"Failed to build edk2",
+				slog.Any("error", err),
+			)
 			return myContainerPrevious, fmt.Errorf("edk2 build failed: %w", err)
 		}
 	}

--- a/action/recipes/recipes.go
+++ b/action/recipes/recipes.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"slices"
 	"sync"
@@ -98,12 +98,12 @@ func Build(
 	slices.Reverse(queue)
 
 	// Build each item in queue (if recursive)
-	log.Printf("building queue: %v", queue)
+	slog.Info(fmt.Sprintf("Building queue: %v", queue))
 	if recursive {
 		builds := []string{}
-		log.Printf("building '%s' recursively", target)
+		slog.Info(fmt.Sprintf("Building '%s' recursively", target))
 		for _, item := range queue {
-			log.Printf("- building %s", item)
+			slog.Info(fmt.Sprintf("Building: %s", item))
 			err = executor(ctx, item, config, interactive)
 			if err != nil {
 				return nil, err
@@ -113,7 +113,7 @@ func Build(
 		return builds, nil
 	}
 	// else build only the target
-	log.Printf("building '%s' NOT recursively", target)
+	slog.Info(fmt.Sprintf("Building '%s' NOT recursively", target))
 	return []string{target}, executor(ctx, target, config, interactive)
 }
 


### PR DESCRIPTION
- part 2: this one only replaces `log.Printf` with `slog` (maybe also removes `log.Fatal`)
- fixes #107 
- requires:
  - #157
  - #147
  - #137 
