### PR TITLE
perf(docker): reduce rust size

### DIFF
--- a/docker/edk2/Dockerfile
+++ b/docker/edk2/Dockerfile
@@ -69,7 +69,7 @@ RUN dpkg --add-architecture i386 && \
     \
     wget --quiet -O rustup.sh https://sh.rustup.rs && \
         chmod +x ./rustup.sh && \
-        ./rustup.sh -y
+        ./rustup.sh -y --profile minimal
 
 
 #=============


### PR DESCRIPTION
- rustup default installation takes up 1.1 GB of space
- the minimal profile should reduce it to half or so
- https://rust-lang.github.io/rustup/concepts/profiles.html

In my defense, I had no idea it is so huge!