### PR TITLE
fix: return not checked in container/ssh.go

### DIFF
--- a/action/container/ssh.go
+++ b/action/container/ssh.go
@@ -75,7 +75,7 @@ func WithWaitPressEnter() SettingsSSH {
 		s.WaitFunc = func() {
 			<-s.TunnelReady
 			fmt.Print("Press ENTER to stop container ")
-			fmt.Scanln()
+			fmt.Scanln() // nolint:errcheck
 			s.TunnelClose <- true
 		}
 	}


### PR DESCRIPTION
We only use the scan function as blocker to for user input. Content of said input is irrelevant. Hence we should be able to ignore any error I believe.