### PR TITLE
ci(dependabot): increase open-pull-requests-limit to default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    open-pull-requests-limit: 1
     reviewers:
       - "AtomicFS"
     assignees:
@@ -27,7 +26,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    open-pull-requests-limit: 1
     reviewers:
       - "AtomicFS"
     assignees:
@@ -38,7 +36,6 @@ updates:
     schedule:
       interval: "daily"
       time: "00:00"
-    open-pull-requests-limit: 1
     groups:
       python:
         update-types:
@@ -54,7 +51,6 @@ updates:
     schedule:
       interval: "daily"
       time: "00:00"
-    open-pull-requests-limit: 1
     groups:
       docker:
         update-types:
@@ -70,7 +66,6 @@ updates:
     schedule:
       interval: "daily"
       time: "00:00"
-    open-pull-requests-limit: 1
     groups:
       golang:
         update-types:


### PR DESCRIPTION
For one I think we can increase the limit since it has been running for a while now.

I added this when enabling `dependabot` for this repository to limit the number of pull requests, since each PR creates a bunch of workflows. And I suspected that it would create a bunch of PRs in the beginning. Now it is no longer needed.

So lets keep it to default, which is `5`.