### PR TITLE
Run docker container builds on release

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -14,6 +14,7 @@ on:
   schedule:
     # Sunday midnight
     - cron: '0 0 * * 0'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -45,18 +46,24 @@ jobs:
             'udk2017'
           ]
     steps:
-        # We have to use my own fork of actions/delete-package-versions at the moment
-        #   to have access to 'dry-run' and 'ignore-versions-include-tags' features
-        # We can switch to upstream whe following PRs get merged:
-        #   - [dry-run](https://github.com/actions/delete-package-versions/pull/119/commits)
-        #   - [tags](https://github.com/actions/delete-package-versions/pull/104
+      # We have to use my own fork of actions/delete-package-versions at the moment
+      #   to have access to 'dry-run' and 'ignore-versions-include-tags' features
+      # We can switch to upstream whe following PRs get merged:
+      #   - [dry-run](https://github.com/actions/delete-package-versions/pull/119/commits)
+      #   - [tags](https://github.com/actions/delete-package-versions/pull/104
       - name: Delete old packages
         uses: AtomicFS/delete-package-versions@main
+        continue-on-error:
+          true
+          # we have continue-on-error because when I make a fork of this repo to debug something,
+          # the Docker containers would not build because this step fails to fetch existing containers
+          # (in fresh fork there are none)
         with:
           package-name: firmware-action/${{ matrix.dockerfile }}
           package-type: container
           min-versions-to-keep: 5
-          ignore-versions: '^(main|latest|v(\d+\.?)+)$'
+          ignore-versions:
+            '^(main|latest|v(\d+\.?)+)$'
             # ignore:
             # - main
             # - latest

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -10,7 +10,7 @@ on:
     branches: ['main']
     paths:
       - 'docker/**'
-    tags: ['v*']
+  release:
   schedule:
     # Sunday midnight
     - cron: '0 0 * * 0'

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -19,7 +19,7 @@ on:
           - patch
 
 permissions:
-  contents: write      # To push new branch
+  contents: write # To push new branch
   pull-requests: write # To create a pull request
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,13 @@ on:
       - closed
 
 permissions:
-  contents: write  # To create a new release
+  contents: read
 
 jobs:
-  release:
+  release-golang:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # To create a new release
     if: startsWith(github.event.pull_request.title, 'Release:') && github.event.pull_request.merged == true
     steps:
       - name: Checkout code
@@ -64,5 +66,41 @@ jobs:
           version: latest
           workdir: action
           args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-docker:
+    # There is a depth limit on workflows triggered by workflows to avoid infinite loops.
+    # This release workflow is triggered by merging a Pull Request made by release-prepare workflow.
+    #
+    # In addition the Docker build cannot really happen because of the `paths` filter in `on.push` event config.
+    # I do not want to change that because then we would build Docker containers all the time, which is long and unnecessary.
+    #
+    # And unfortunately a workflow cannot easily trigger another (Docker container builds) because of other GitHub limits.
+    # However it is possible to use API to trigger a workflow. That is what this job is for.
+    #
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      packages: write
+    steps:
+      - name: Trigger dagger workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'docker-build-and-test.yml',
+                ref: context.ref,
+              })
+              console.log(result);
+            } catch(error) {
+              console.error(error);
+              core.setFailed(error);
+            }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
OK, this is a bit cumbersome, but it should fix the problem then a new release does not trigger a build of Docker containers.