### PR TITLE
fix(ci): skip on all reviews except when the release PR

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -29,6 +29,8 @@ jobs:
     strategy:
       matrix:
         coreboot-version: ['4.19', '4.20.1', '4.21', '24.02']
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -78,6 +80,8 @@ jobs:
     strategy:
       matrix:
         linux-version: [6.1.45]
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -137,6 +141,8 @@ jobs:
     strategy:
       matrix:
         edk2-version: ['edk2-stable202208', 'edk2-stable202211']
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -186,6 +192,8 @@ jobs:
     strategy:
       matrix:
         coreboot-version: ['4.19']
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -232,6 +240,8 @@ jobs:
     strategy:
       matrix:
         uroot-version: ['v0.14.0']
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -21,6 +21,8 @@ jobs:
     strategy:
       matrix:
         testregex: ['TestLinux', 'TestEdk2', 'TestCoreboot', 'TestStitching', 'TestURoot']
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,6 +45,8 @@ jobs:
   go-test:
     # Run all remaining light tests
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ permissions:
 jobs:
   commit-lint:
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,6 +38,8 @@ jobs:
           configFile: .commitlint.config.mjs
   megalinter:
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,6 +52,8 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
   golangci-lint:
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Install Taskfile
         run: |


### PR DESCRIPTION
- it is just doubling number of CIs of each PR
- we have this only because the release PR does not trigger corectly workflows, because we have too many nested triggers I think (github has a limit to prevent infinite loops)
- this fix should shopefully skip PR review trigger when the PR is not made by the github-actions[bot] which we use for releases