### PR TITLE
fix(lint): fix frequent markdown-link-check fail with AUR link

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://aur.archlinux.org/packages/.*"
+    }
+  ]
+}


### PR DESCRIPTION
The link test of AUR fails very often, so let's ignore it.