### PR TITLE
fix(release): release-prepare missing tags and history

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Get cocogitto
         run: |


### PR DESCRIPTION
- workflow release-prepare does not get current version, and defaults to current version being v0.0.0
- for workflow release-prepare to correctly get current we need the whole history and all tags