### PR TITLE
fix(action): remove unnecessary apostrophes

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -51,7 +51,7 @@ jobs:
           sed -i -E "s/SEMVER: .*/SEMVER: '${{ steps.update_version.outputs.version }}'/g" Taskfile.yml
       - name: Update action.yml
         run: |
-          sed -i -E "s/version=v[a-zA-Z0-9\.]+/version='${{ steps.update_version.outputs.version }}'/g" action.yml
+          sed -i -E "s/version=v[a-zA-Z0-9\.]+/version=${{ steps.update_version.outputs.version }}/g" action.yml
 
       - name: Update changelog
         run: |

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - id: version
       shell: bash
-      run: echo "version='v0.4.0'" >> "${GITHUB_OUTPUT}"
+      run: echo "version=v0.4.0" >> "${GITHUB_OUTPUT}"
 
     - id: arch
       shell: bash


### PR DESCRIPTION
We are getting some failures when the action is trying to download the executable from releases.

Right now it just downloads a small text file with `Not found` written inside it. This is because of the apostrophes surrounding the `firmware-actin` version in the URL.