### PR TITLE
fix(ci): consolidate multiple jobs into few status checks

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -31,6 +31,25 @@ permissions:
   contents: read
 
 jobs:
+  # Status check for all jobs below
+  # This is to allow SKIPPED be considered as SUCCESS
+  status-check-example:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - build-coreboot
+      - build-linux
+      - build-edk2
+      - build-stitching
+      - build-uroot
+      - test-operating-systems
+    steps:
+      - name: Check status
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: ${{ toJSON(needs) }}
+          jobs: ${{ toJSON(needs) }}
+
   # Change detection in action golang code
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -21,6 +21,21 @@ permissions:
   contents: read
 
 jobs:
+  # Status check for all jobs below
+  # This is to allow SKIPPED be considered as SUCCESS
+  status-check-go-test:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - go-test-resource-hogs
+      - go-test
+    steps:
+      - name: Check status
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: ${{ toJSON(needs) }}
+          jobs: ${{ toJSON(needs) }}
+
   go-test-resource-hogs:
     # Run tests that take up a lot of system resources separately
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,6 +21,20 @@ permissions:
   contents: read
 
 jobs:
+  # Status check for all jobs below
+  # This is to allow SKIPPED be considered as SUCCESS
+  status-check-pytest:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - pytest
+    steps:
+      - name: Check status
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: ${{ toJSON(needs) }}
+          jobs: ${{ toJSON(needs) }}
+
   pytest:
     runs-on: ubuntu-latest
     if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}


### PR DESCRIPTION
- some jobs take a while so we skip them if unnecessary
- they show up as SKIPPED
- problem is that SKIPPED is considered FAILED and we cannot have these as required status checks
- this allows us to change this behavior