### PR TITLE
fix(ci): jobs are canceled on submitted review

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -24,7 +24,7 @@ env:
   APPLY_FIXES_EVENT: pull_request
   APPLY_FIXES_MODE: commit
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ env:
   APPLY_FIXES_EVENT: pull_request
   APPLY_FIXES_MODE: commit
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
- we are using pull_request_review.submitted trigger to have CIs running for release PRs and releases
- the issue is that when someone submits a review on ordinary PR, it creates a bunch of jobs which are immediately skipped, but they still cancel already running jobs because they are in the same group