### PR TITLE
fix(dagger): missing docker-compose

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -130,7 +130,9 @@
   ],
   "ignoreWords": [
     "Eeuo",
+    "Kengo",
     "Ovmf",
+    "TODA",
     "aarch",
     "alecthomas",
     "anyio",

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -87,6 +87,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup docker-compose
+        uses: KengoTODA/actions-setup-docker-compose@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Validate compose file
         run: docker-compose -f docker/compose.yaml config
 


### PR DESCRIPTION
Sometimes the docker-compose executable is missing for some reason.

See failing [v0.5.0 release dagger workflow](https://github.com/9elements/firmware-action/actions/runs/10195463439)
