### PR TITLE
feat(docker): build coreboot cross-compilers for all platforms

### DIFF
--- a/docker/coreboot/Dockerfile
+++ b/docker/coreboot/Dockerfile
@@ -75,10 +75,7 @@ FROM base AS toolchain
 WORKDIR $TOOLSDIR
 RUN git clone --depth 1 "https://review.coreboot.org/coreboot.git" -b "${COREBOOT_VERSION}"
 WORKDIR $TOOLSDIR/coreboot
-RUN make crossgcc-aarch64 CPUS="$(nproc)" && \
-    make crossgcc-arm CPUS="$(nproc)" && \
-    make crossgcc-i386 CPUS="$(nproc)" && \
-    make crossgcc-x64 CPUS="$(nproc)"
+RUN make crossgcc CPUS="$(nproc)"
 WORKDIR $TOOLSDIR/coreboot
 RUN make -C util/ifdtool install && \
     make -C util/cbfstool install


### PR DESCRIPTION
- if I am not mistaken we selected only few platforms to to save on compile time when building the docker containers
- since we are no longer building docker containers for each and every commit and/or pull request, I think we can support all platforms
- instead of 40 minutes per container it takes 60 minutes