### PR TITLE
fix(lint): ignore review.coreboot.org links

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://aur.archlinux.org/packages/.*"
+    },
+    {
+      "pattern": "^https://review.coreboot.org/.*"
     }
   ]
 }


### PR DESCRIPTION
The server is down for a while now and it prevents PR from merging