### PR TITLE
Fix/taskfile

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -67,9 +67,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
-      - name: Install Taskfile
-        run: |
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
       - name: Install go dependencies
         run: |
           cd action
@@ -92,9 +89,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
-      - name: Install Taskfile
-        run: |
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
       - name: Install go dependencies
         run: |
           cd action

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,7 +8,7 @@ tasks:
     desc: Template task to build a go binary
     dir: action
     cmds:
-      - go build -ldflags="-s -w" -o ../bin/firmware-action-{{.OS}}-amd64-{{.SEMVER}}
+      - go build -ldflags="-s -w" -o ../bin/firmware-action-{{OS}}-{{ARCH}}-{{.SEMVER}}
     env:
       CGO_ENABLED: 0
 


### PR DESCRIPTION
- remove leftover junk in go-test workflow
- remove deploy-binaries task from taskfile, we no longer need to build all binaries with taskfile (binaries for releases are build with GoReleaser in release workflow)
- remove upx compression from taskfile since it just adds additional time with minimal benefits


fixes #324 