### PR TITLE
feat(docker): make containers multi-arch

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -46,6 +46,7 @@
     "NOTSET",
     "REPOPATH",
     "TARGETARCH",
+    "TOOLSDIR",
     "Taskfile",
     "acpica",
     "addinivalue",

--- a/.dagger-ci/daggerci/tests/test_orchestrator.py
+++ b/.dagger-ci/daggerci/tests/test_orchestrator.py
@@ -41,8 +41,14 @@ async def test__orchestrator__broken_dockerfile(
     result = await my_orchestrator.build_test_publish()
     assert "services" in result.results
     assert "coreboot_4.19" in result.results["services"]
-    assert "build" in result.results["services"]["coreboot_4.19"]
-    assert result.results["services"]["coreboot_4.19"]["build"] is False
+
+    # because of multi-platform nature we have to be flexible
+    build_found = False
+    for key, _ in result.results["services"]["coreboot_4.19"].items():
+        if re.match("build .*", key) and not re.match(".*_msg$", key):
+            build_found = True
+            assert result.results["services"]["coreboot_4.19"][key] is False
+    assert build_found
 
 
 @pytest.mark.slow

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -255,7 +255,7 @@ jobs:
   build:
     name: build_test_publish
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 60
     needs:
       - get-matrix
       - build-coreboot-toolchains
@@ -302,6 +302,95 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get coreboot version
+        id: version
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: yq -r '.services.["${{ matrix.dockerfile }}"].build.args[] | select(test("COREBOOT_VERSION=.*"))' docker/compose.yaml >> "${GITHUB_OUTPUT}"
+      - name: Clone coreboot
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          git clone --depth 1 "https://review.coreboot.org/coreboot.git" -b "${{ steps.version.outputs.COREBOOT_VERSION }}"
+      - name: Get coreboot commit hash
+        id: coreboot-hash
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          cd coreboot
+          COREBOOT_HASH="$( git rev-parse --short HEAD )"
+          echo "${COREBOOT_HASH}"
+          echo "COREBOOT_HASH=${COREBOOT_HASH}" >> "${GITHUB_OUTPUT}"
+      - name: Artefact and cache key
+        id: cache-key
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          CACHE_KEY="coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}-${{ steps.coreboot-hash.outputs.COREBOOT_HASH }}"
+          echo "CACHE_KEY=${CACHE_KEY}"
+          echo "CACHE_KEY=${CACHE_KEY}" >> "${GITHUB_OUTPUT}"
+
+      #=================================
+      # Download artifacts for coreboot
+      #=================================
+
+      - name: Download coreboot toolchains from current run (if possible)
+        id: artifacts-toolchains-current
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: ${{ steps.cache-key.outputs.CACHE_KEY }}-.*
+          name_is_regexp: true
+          if_no_artifact_found: warn
+          run_id: ${{ github.event.workflow_run.id }}
+        # It is possible that current run did not produce any artifacts (to save bandwidth on self-hosted runners)
+        # In which case we have to look for artifacts in older runs
+      - name: Download coreboot toolchains from older run
+        if: startsWith(matrix.dockerfile, 'coreboot') && steps.artifacts-toolchains-current.outputs.found_artifact != 'true'
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: ${{ steps.cache-key.outputs.CACHE_KEY }}-.*
+          name_is_regexp: true
+          search_artifacts: true
+
+      - name: Prepare toolchains
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          mkdir -p docker/coreboot/coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}
+          for f in ${{ steps.cache-key.outputs.CACHE_KEY }}-*-xgcc/*.tar; do
+            ARCH=$( basename "${f}" | sed -E 's/coreboot\-[0-9\.]+\-[a-z0-9]+\-([a-z0-9]+)\-.*/\1/g' )
+            echo "extracting ${f} -> ${{ steps.version.outputs.COREBOOT_VERSION }} / ${ARCH}"
+            mkdir -p "${f}.dir/"
+            tar -xf "${f}" -C "${f}.dir/"
+            mv "${f}.dir/coreboot/util/crossgcc/${ARCH}-xgcc" "docker/coreboot/coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}/xgcc-${ARCH}"
+          done
+      - name: Prepare utils
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          for f in ${{ steps.cache-key.outputs.CACHE_KEY }}-*-utils; do
+            ARCH=$( basename "${f}" | sed -E 's/coreboot\-[0-9\.]+\-[a-z0-9]+\-([a-z0-9]+)\-.*/\1/g' )
+            echo "${f} -> ${{ steps.version.outputs.COREBOOT_VERSION }} / ${ARCH}"
+            chmod +rx "${f}"/*
+            mv "${f}" "docker/coreboot/coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}/utils-${ARCH}"
+          done
+
+      - name: Debug list artifacts
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          ls -a1lh docker/coreboot/coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}/
+      - name: Debug list xgcc (amd64)
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          ls -a1lh docker/coreboot/coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}/xgcc-*
+      - name: Debug list xgcc/bin (amd64)
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          ls -a1lh docker/coreboot/coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}/xgcc-*/bin
+      - name: Debug list utils (amd64)
+        if: startsWith(matrix.dockerfile, 'coreboot')
+        run: |
+          ls -a1lh docker/coreboot/coreboot-${{ steps.version.outputs.COREBOOT_VERSION }}/utils-*
+
+      #============================
+      # Build the docker container
+      #============================
+
       - name: Setup docker-compose
         uses: KengoTODA/actions-setup-docker-compose@v1
         env:
@@ -314,8 +403,7 @@ jobs:
         run: pip install -r ./.dagger-ci/daggerci/requirements.txt
 
       - name: Run dagger pipeline
-        # If building coreboot use 120 minutes timeout, otherwise 15 minutes
-        timeout-minutes: ${{ startsWith(matrix.dockerfile, 'coreboot_') && 120 || 15 }}
+        timeout-minutes: 60
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == 'release' ]] || [[ "${GITHUB_REF}" == *'main' ]] || [[ "${GITHUB_REF_TYPE}" == 'tag' ]]; then
             echo "Enable publishing"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ megalinter-reports
 node_modules
 action/recipes/__tmp_files__/
 output-*/
+docker/coreboot/coreboot-*

--- a/docker/coreboot/Dockerfile
+++ b/docker/coreboot/Dockerfile
@@ -11,11 +11,12 @@ FROM ${SOURCE_IMAGE} AS base
 ARG TARGETARCH
 
 ARG COREBOOT_VERSION=4.19
+ENV COREBOOT_VERSION=${COREBOOT_VERSION}
 ARG CONTEXT=coreboot
 
 # Verification test
 ENV VERIFICATION_TEST=./tests/test_${CONTEXT}.sh
-ENV VERIFICATION_TEST_COREBOOT_VERSION=$COREBOOT_VERSION
+ENV VERIFICATION_TEST_COREBOOT_VERSION=${COREBOOT_VERSION}
 
 ENV DEBIAN_FRONTEND=noninteractive
 # Directory for coreboot toolchain, MEAnalyser etc.
@@ -68,37 +69,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p "${TOOLSDIR}"
 
-
-#=============
-# "toolchain" stage to build the coreboot toolchain
-FROM base AS toolchain
-
-# Compile coreboot toolchain
-WORKDIR $TOOLSDIR
-RUN git clone --depth 1 "https://review.coreboot.org/coreboot.git" -b "${COREBOOT_VERSION}"
-WORKDIR $TOOLSDIR/coreboot
-RUN make crossgcc CPUS="$(nproc)"
-WORKDIR $TOOLSDIR/coreboot
-RUN make -C util/ifdtool install && \
-    make -C util/cbfstool install
-
-# Install MEAnalyser
-WORKDIR $TOOLSDIR
-RUN git clone https://github.com/platomav/MEAnalyzer.git
-
-
-#=============
-# "final" stage is the actual product with everything included
-FROM base AS final
-
 # Let coreboot know the toolchain path
-ENV XGCCPATH=$TOOLSDIR/coreboot/util/crossgcc/xgcc/bin/
-RUN echo "${XGCCPATH}"
+ENV XGCCPATH=${TOOLSDIR}/coreboot/util/crossgcc/xgcc/bin/
 
-# Copy over things from previous stage(s)
-COPY --from=toolchain $XGCCPATH/.. $XGCCPATH/..
-COPY --from=toolchain $TOOLSDIR/MEAnalyzer $TOOLSDIR/
-COPY --from=toolchain /usr/local/bin/* /usr/local/bin/
+# Add pre-compiled coreboot toolchain and utils
+COPY coreboot-${COREBOOT_VERSION}/xgcc-${TARGETARCH} ${TOOLSDIR}/coreboot/util/crossgcc/xgcc
+COPY coreboot-${COREBOOT_VERSION}/utils-${TARGETARCH}/* /usr/local/bin/
+RUN git clone --depth 1 https://github.com/platomav/MEAnalyzer.git ${TOOLSDIR}/MEAnalyzer/
 
 # Prepare SSH for interactive debugging
 RUN mkdir -p /run/sshd && \

--- a/docker/edk2/Dockerfile
+++ b/docker/edk2/Dockerfile
@@ -142,7 +142,9 @@ RUN mkdir Edk2 && \
     git fetch --depth 1 origin "${EDK2_VERSION_COMMIT}" && \
     git checkout "${EDK2_VERSION_COMMIT}" && \
     git submodule update --init --recursive && \
-    make -C BaseTools/ -j "$(nproc)"
+    if [ "${TARGETARCH}" = 'amd64' ]; then \
+        make -C BaseTools/ -j "$(nproc)"; \
+    fi;
 
 
 #=============

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -8,6 +8,7 @@ ARG TARGETARCH=amd64
 # "base" stage with all needed build dependencies
 FROM ${SOURCE_IMAGE} AS base
 
+ARG TARGETARCH
 ARG LINUX_VERSION=6.1.45
 ARG CONTEXT=linux
 
@@ -35,7 +36,6 @@ RUN apt-get update && \
         g++-${GCC_VERSION} \
         gawk \
         gcc-${GCC_VERSION} \
-        gcc-${GCC_VERSION}-aarch64-linux-gnu \
         gcc-${GCC_VERSION}-arm-linux-gnueabi \
         gcc-${GCC_VERSION}-i686-linux-gnu \
         git \
@@ -52,6 +52,10 @@ RUN apt-get update && \
         wget \
         zstd \
     && \
+    if [ "${TARGETARCH}" = 'amd64' ]; then \
+        apt-get install -y --no-install-recommends \
+            gcc-${GCC_VERSION}-aarch64-linux-gnu; \
+    fi && \
     apt-get install -y --no-install-recommends \
         less \
         nano \


### PR DESCRIPTION
This makes all of our containers [multi-architectural / multi-platform](https://docs.docker.com/build/building/multi-platform/) and fixes #341 .

At the moment we only support `x86_64` (aka `amd64`) and `arm64` (specifically `arm64 v8`).

Todo:
- [x] uroot (this was no work)
- [x] linux (this was easy)
- [x] coreboot (took some effort but works)
- [x] edk2 (this is pain)
  - [x] build the toolchains on the fly for non-x86 architectures (first use by user)
    - this is kinda difficult to test at the moment


There is a lot to comprehend, so here are some notes as to why:
- `u-root` and `linux` are OK to build the "normal way", however with `edk2` and `coreboot` I get errors when trying to compile to tool-chains - I suspect the problem to be native emulation not supporting all of the instructions required
  - building `x86` on `x86` machine and `arm64` on `arm64` works fine, but building `arm64` on `x86` machine is broken (and vice versa)
- this means that I cannot build `edk2` or `coreboot` multi-arch container on single `x86` machine as I can `u-root` or `linux`
- I looked into cross-compilation - aka cross-compile the cross-compilation tool-chains ... well that did not go well
  - it should be possible, but it seems like a long process not worth the time investment
- one way would be to build each arch-container separately (`x86` part on `x86` machine and `arm64` part on `arm64` machine), publish them separately and then publish hand-crafted manifest connecting them together ... (see `The hard way with docker manifest` in [Multi-arch build and images, the simple way](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/)
- but we can avoid all of that with simply compiling the tool-chains separately on their respective machines and then just copy files into single multi-arch container (which can be done without any problems with simple native emulation)
  - **UPDATE**: `coreboot` is fine, but `edk2` is too much hassle (see #368)
- one advantage of separate tool-chain compilation is that this way we can cache the compiled tool-chains for `coreboot` and speed up the build by one order of magnitude (normally they take around 1 hour to compile)
- as I was running out of disk-space for coreboot docker container I decided to use [upx](https://archlinux.org/packages/extra/x86_64/upx/) to compress the toolchain reducing the size from around 1.5 GB down to 1.0 GB (as a nice side-effect the whole container is smaller)
- as it stands now, we are not testing if the multi-arch containers work on other than `x86` architectures, since it is not really possible right now. We can only verify that the new changes did not break existing functionality.


This is the final PR in the multi-arch saga, which contains breaking changes.
- #355
- #356
- #359
- #360
- #361
- #362
- #366
- #367
- #368