### PR TITLE
feat(ci): add 2nd part to reminder bot

### DIFF
--- a/.github/workflows/bot--reminder-schedule.yml
+++ b/.github/workflows/bot--reminder-schedule.yml
@@ -1,0 +1,20 @@
+---
+# Docs: https://github.com/agrc/reminder-action
+#   create-reminder-action cannot be scheduled
+#   for scheduled runs this is needed
+name: 'reminder-schedule'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  reminder-schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check reminders and notify
+        uses: agrc/reminder-action@v1


### PR DESCRIPTION
I noticed that the reminderbot does not work yet on #302 , and then I found out I missed a important detail.

In the first PR #303 I forgot that the reminder bot consists of two separate parts, but it should have become apparent with #328.

Anyway:
- 1st part creates the label and metadata on issue creation
- 2nd part runs on schedule and checks labeled issues