### PR TITLE
fix(docker): enable again tests of containers

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -5,11 +5,13 @@ name: dagger
 on:
   pull_request:
     paths:
+      - '.dagger-ci'
       - '.github/workflows/docker-build-and-test.yml'
       - 'docker/**'
   push:
     branches: ['main']
     paths:
+      - '.dagger-ci'
       - '.github/workflows/docker-build-and-test.yml'
       - 'docker/**'
   release:


### PR DESCRIPTION
This time the tests are done without tarball export and import which should save up a lot of disk space and a bit of CI time.

fixes #338 