### PR TITLE
feat(docker): add zstd into linux container

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && \
         nodejs \
         openssl \
         wget \
+        zstd \
     && \
     apt-get install -y --no-install-recommends \
         less \


### PR DESCRIPTION
I just noticed that the Linux docker container is missing `zstd`, lol