### PR TITLE
ci(docker): build monthly instead of weekly

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -18,8 +18,8 @@ on:
       - 'tests/**'
   release:
   schedule:
-    # Sunday midnight
-    - cron: '0 0 * * 0'
+    # First day of the month at midnight
+    - cron: '0 0 1 * 0'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
- I don't think we need to re-build the containers this often