### PR TITLE
ci(reminder): run daily instead of hourly

### DIFF
--- a/.github/workflows/bot--reminder-schedule.yml
+++ b/.github/workflows/bot--reminder-schedule.yml
@@ -6,7 +6,7 @@ name: 'reminder-schedule'
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
 
 permissions:
   issues: write


### PR DESCRIPTION
For those few reminders that we have there is no need to have hourly resolution. Daily is more than sufficient.