### PR TITLE
fix(docker): bump all linux docker containers to noble release

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -144,7 +144,7 @@ services:
       args:
         - LINUX_VERSION=6.1.45
         - GCC_VERSION=11
-        - SOURCE_IMAGE=ubuntu:jammy
+        - SOURCE_IMAGE=ubuntu:noble
   linux_6.1.111:
     # 2022-12
     # LTS
@@ -153,7 +153,7 @@ services:
       args:
         - LINUX_VERSION=6.1.111
         - GCC_VERSION=11
-        - SOURCE_IMAGE=ubuntu:jammy
+        - SOURCE_IMAGE=ubuntu:noble
   linux_6.6.52:
     # 2023-10
     # LTS
@@ -162,7 +162,7 @@ services:
       args:
         - LINUX_VERSION=6.6.52
         - GCC_VERSION=12
-        - SOURCE_IMAGE=ubuntu:jammy
+        - SOURCE_IMAGE=ubuntu:noble
   linux_6.9.9:
     # 2024-05
     build:


### PR DESCRIPTION
First of all, I don't think this will have any effect on the containers or their usage.

During building of the `multi-arch` containers there were multiple issues:
- missing `gpg2` executable for arm64
- missing `gcc-11-aarch64-linux-gnu` package
  - became available only since ubuntu noble (24.04) for arm64

I just don't see any benefit of trying to keep using ubuntu jammy (22.04) since Linux kernel should compile almost anywhere.