### PR TITLE
chore(docker): remove unnecessary dependencies

### DIFF
--- a/docker/coreboot/Dockerfile
+++ b/docker/coreboot/Dockerfile
@@ -65,11 +65,6 @@ RUN apt-get update && \
         vim \
     && \
     dpkg-reconfigure --frontend noninteractive tzdata && \
-    pip3 install --no-cache-dir \
-        colorama==0.4.6 \
-        crccheck==1.3.0 \
-        pltable==1.0.2 \
-    && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p "${TOOLSDIR}"
 


### PR DESCRIPTION
This is still a leftover from original Dockerfile from February 2023 2dbdbb581e6e99446a7896a5698e3aa23a286e8a. I don't think we actually need this.