### PR TITLE
expand taskfile

### DIFF
--- a/.dagger-ci/Taskfile.yml
+++ b/.dagger-ci/Taskfile.yml
@@ -2,6 +2,7 @@
 version: '3'
 vars:
   PROJECT: 'daggerci'
+  PYTHON_VENV: 'venvdagger'
 
 tasks:
   lint-pylint:
@@ -27,3 +28,27 @@ tasks:
     dir: daggerci
     cmds:
       - python -m pytest --cov --cov-report=term-missing --cov-report=html --log-cli-level NOTSET --show-capture no --log-cli-level=INFO --runslow {{.CLI_ARGS}}
+
+  setup-python-venv:
+    desc: Setup python virtual environment
+    internal: true
+    cmds:
+      - python -m venv {{.PYTHON_VENV}}
+      - bash -c "
+        source {{.PYTHON_VENV}}/bin/activate;
+        pip install -r ./daggerci/requirements.txt;
+        "
+    sources:
+      - ./daggerci/requirements.txt
+    generates:
+      - ./{{.PYTHON_VENV}}/pyvenv.cfg
+
+  test-venv:
+    desc: Run tests in virtual environment
+    deps: [setup-python-venv]
+    cmds:
+      - bash -c "
+        source {{.PYTHON_VENV}}/bin/activate;
+        cd daggerci;
+        python -m pytest --cov --cov-report=term-missing --cov-report=html --log-cli-level NOTSET --show-capture no --log-cli-level=INFO --runslow {{.CLI_ARGS}};
+        "

--- a/.dagger-ci/Taskfile.yml
+++ b/.dagger-ci/Taskfile.yml
@@ -34,7 +34,8 @@ tasks:
     internal: true
     cmds:
       - python -m venv {{.PYTHON_VENV}}
-      - bash -c "
+      - |
+        bash -c "
         source {{.PYTHON_VENV}}/bin/activate;
         pip install -r ./daggerci/requirements.txt;
         "
@@ -47,8 +48,53 @@ tasks:
     desc: Run tests in virtual environment
     deps: [setup-python-venv]
     cmds:
-      - bash -c "
+      - |
+        bash -c "
         source {{.PYTHON_VENV}}/bin/activate;
         cd daggerci;
         python -m pytest --cov --cov-report=term-missing --cov-report=html --log-cli-level NOTSET --show-capture no --log-cli-level=INFO --runslow {{.CLI_ARGS}};
         "
+
+  #==================
+  # Build containers
+  #==================
+
+  build:
+    desc: Build docker container
+    internal: true
+    deps: [setup-python-venv]
+    cmds:
+      - |
+        bash -c "
+        source {{.PYTHON_VENV}}/bin/activate;
+        cd ..;
+        python .dagger-ci/daggerci/main.py -d {{.DOCKERFILE}};
+        "
+    requires:
+      vars: [DOCKERFILE]
+
+  build:help:
+    desc: Print help
+    cmds:
+      - echo "To build a container simply run:"
+      - echo "  \$ task build:container-<VARIANT>"
+      - echo "For example:"
+      - echo "  \$ task build:container-coreboot_24.05"
+      - echo "To see all available variants, run:"
+      - echo "  \$ task build:list-available"
+    silent: true
+
+  build:list-available:
+    desc: List available container variants to build
+    cmds:
+      - yq '.services | keys[]' ../docker/compose.yaml | sed 's/"//g'
+    silent: true
+
+  build:container-*:
+    desc: Build a container variant
+    vars:
+      VARIANT: '{{index .MATCH 0}}'
+    cmds:
+      - task: build
+        vars:
+          DOCKERFILE: '{{.VARIANT}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,12 @@ version: '3'
 vars:
   SEMVER: 'v0.6.1'
 
+includes:
+  containers:
+    taskfile: ./.dagger-ci/Taskfile.yml
+    dir: ./.dagger-ci
+    optional: true
+
 tasks:
   build-go-binary:
     desc: Template task to build a go binary


### PR DESCRIPTION
I am adding a new task into the `Taskfile.yml` inside `.dagger-ci` directory, which simplifies building single docker containers (mostly for development purposes).

I am also linking the the two taskfiles (the main one and one in the `.dagger-ci` directory) for simplicity.

Building coreboot containers will be a bit problematic after the #343 is merged because it will require to have pre-compiled tool-chain ready on disk :(