### PR TITLE
ci: dependabot git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,9 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-    reviewers:
-      - 'AtomicFS'
-    assignees:
-      - 'AtomicFS'
 
   - package-ecosystem: pip
     directory: '/.dagger-ci/daggerci'
@@ -26,10 +22,6 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-    reviewers:
-      - 'AtomicFS'
-    assignees:
-      - 'AtomicFS'
 
   - package-ecosystem: docker
     directory: '/docker'
@@ -41,10 +33,6 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-    reviewers:
-      - 'AtomicFS'
-    assignees:
-      - 'AtomicFS'
 
   - package-ecosystem: gomod
     directory: '/action'
@@ -56,7 +44,3 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-    reviewers:
-      - 'AtomicFS'
-    assignees:
-      - 'AtomicFS'


### PR DESCRIPTION
Let's use dependabot to keep our git submodules up-to-date.