### PR TITLE
ci: a bit more automation to pull requests

### DIFF
--- a/.github/workflows/bot--automerge.yml
+++ b/.github/workflows/bot--automerge.yml
@@ -1,0 +1,40 @@
+---
+# Auto-merging
+name: 'auto-merge'
+
+on:
+  - pull_request
+
+permissions: read-all
+
+jobs:
+  # Enable auto-merge on all pull requests by default
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Enable pull request auto-merge
+        run: |
+          gh pr merge --auto "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # If PR is made by dependabot, automatically approve the PR
+  # Linting and all checks will still have to pass in order for the PR to be merged
+  auto-approve-dependabot:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Auto approve dependabot pull requests
+        if: github.actor == 'dependabot[bot]'
+        run: |
+          gh pr review "${{ github.event.pull_request.number }}" --approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- automatically enable auto-merge on all pull requests
- if pull request is made by dependabot, also automatically approve it
- the dependabot pull request will still have to pass required checks in order to be merged

Inspired by [peter-evans/enable-pull-request-automerge](https://github.com/marketplace/actions/enable-pull-request-automerge)