### PR TITLE
ci(automerge): do not run on draft PR

### DIFF
--- a/.github/workflows/bot--automerge.yml
+++ b/.github/workflows/bot--automerge.yml
@@ -3,7 +3,8 @@
 name: 'auto-merge'
 
 on:
-  - pull_request
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: read-all
 
@@ -14,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
These jobs fail when PR is just a draft

`pull_request` types by default include:
- opened
- synchronize
- reopened

So I added `ready_for_review`. This way, when the PR is converted from `Draft` to `Ready for review` it will also trigger the jobs.