### PR TITLE
fix(ci/automerge): use PAT token

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -51,6 +51,7 @@
     "acpica",
     "addinivalue",
     "addoption",
+    "automerge",
     "autopep",
     "blkio",
     "bsdmainutils",

--- a/.github/workflows/bot--automerge.yml
+++ b/.github/workflows/bot--automerge.yml
@@ -10,6 +10,7 @@ permissions: read-all
 
 jobs:
   # Enable auto-merge on all pull requests by default
+  # Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
   enable-auto-merge:
     runs-on: ubuntu-latest
     permissions:
@@ -23,10 +24,11 @@ jobs:
         run: |
           gh pr merge --auto "${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT_AUTOMERGE }}
 
   # If PR is made by dependabot, automatically approve the PR
   # Linting and all checks will still have to pass in order for the PR to be merged
+  # Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request
   auto-approve-dependabot:
     runs-on: ubuntu-latest
     permissions:
@@ -36,8 +38,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Auto approve dependabot pull requests
-        if: github.actor == 'dependabot[bot]'
+        if: ${{ github.actor == 'dependabot[bot]' }}
         run: |
           gh pr review "${{ github.event.pull_request.number }}" --approve
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT_AUTOMERGE }}


### PR DESCRIPTION
My theory as to why GitHub does not trigger check jobs when Auto-merge is enabled by our bot is that GitHub does not allow ordinary `GITHUB_TOKEN` to trigger other workflows. Probably to avoid endless recursion.

We had this problem also with releases. So I hope that using PAT might fix this.