### PR TITLE
chore(dependabot): remove docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,17 +23,6 @@ updates:
           - 'minor'
           - 'patch'
 
-  - package-ecosystem: docker
-    directory: '/docker'
-    schedule:
-      interval: 'daily'
-      time: '00:00'
-    groups:
-      docker:
-        update-types:
-          - 'minor'
-          - 'patch'
-
   - package-ecosystem: gomod
     directory: '/action'
     schedule:


### PR DESCRIPTION
- we never use it anyway
- when I added it I was young and foolish, did not read the documentation properly
- all it would do is to add some metadata, and now I do not see any benefits

[Docs](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#docker)