### PR TITLE
fix(ci): replace only first semver in Taskfile

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -36,7 +36,7 @@ jobs:
           sed -i -E 's/const firmwareActionVersion = .*/const firmwareActionVersion = "${{ steps.semver.outputs.next }}"/g' action/main.go
       - name: Update Taskfile.yml
         run: |
-          sed -i -E "s/SEMVER: .*/SEMVER: '${{ steps.semver.outputs.next }}'/g" Taskfile.yml
+          sed -i -E "s/^  SEMVER: .*/  SEMVER: '${{ steps.semver.outputs.next }}'/g" Taskfile.yml
       - name: Update action.yml
         run: |
           sed -i -E "s/version=v[a-zA-Z0-9\.]+/version=${{ steps.semver.outputs.next }}/g" action.yml


### PR DESCRIPTION
- as it was until now, the 'sed' replaces all occurances of SEMVER
- this way, only the first global SEMVER will be replaced