### PR TITLE
fix/automerge

### DIFF
--- a/.github/workflows/bot--automerge.yml
+++ b/.github/workflows/bot--automerge.yml
@@ -3,7 +3,7 @@
 name: 'auto-merge'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: read-all

--- a/.github/workflows/bot--automerge.yml
+++ b/.github/workflows/bot--automerge.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    continue-on-error: true
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
@@ -33,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    continue-on-error: true
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout


### PR DESCRIPTION
- fix so that automerge jobs can fail (they are not important)
- fix so that automerge jobs have access to repository secrets and can actually auto-merge stuff

From commit message:
- run automerge on pull_request_target instead of pull_request
- pull_request does not have access to repository secrets (since the CI runs on the pull_request code which might me malicious)
- pull_request_target instead runs on target branch code and has access to repository secrets
- pull_request_target is fine for automerge
- explaining [stackoverflow post](https://stackoverflow.com/a/74959635)