### PR TITLE
fix(ci): next version calculation

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           token: ${{ github.token }}
           branch: ${{ github.ref }}
+          noVersionBumpBehavior: patch
       - name: Filter
         uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           token: ${{ github.token }}
           branch: main
+          noVersionBumpBehavior: patch
 
       # Bump version
       - name: Update main.go


### PR DESCRIPTION
- by default ietf-tools/semver-action errors when none of the commits results in a version bump
- configure the action to bump patch instead