### PR TITLE
feat: detect changes in sources

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -175,6 +175,7 @@
     "heimdalr",
     "hhmmss",
     "htmlcov",
+    "jedib",
     "ldflags",
     "mypy",
     "opengrabeso",

--- a/action/filesystem/filesystem.go
+++ b/action/filesystem/filesystem.go
@@ -232,7 +232,7 @@ func AnyFileNewerThan(path string, givenTime time.Time) (bool, error) {
 	if errors.Is(err, ErrPathIsDirectory) {
 		errMod := filepath.WalkDir(path, func(path string, info os.DirEntry, _ error) error {
 			// skip .git
-			if info.Name() == ".git" {
+			if info.Name() == ".git" && info.IsDir() {
 				return filepath.SkipDir
 			}
 			if !info.IsDir() {

--- a/action/filesystem/filesystem.go
+++ b/action/filesystem/filesystem.go
@@ -126,7 +126,11 @@ func MoveFile(pathSource, pathDestination string) error {
 func DirTree(root string) ([]string, error) {
 	var files []string
 
-	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
+	// WalkDir is faster than Walk
+	// https://pkg.go.dev/path/filepath#Walk
+	//   > Walk is less efficient than WalkDir, introduced in Go 1.16, which avoids
+	//   > calling os.Lstat on every visited file or directory.
+	err := filepath.WalkDir(root, func(path string, info os.DirEntry, _ error) error {
 		foundItem := path
 		if info.IsDir() {
 			foundItem = fmt.Sprintf("%s/", path)

--- a/action/filesystem/filesystem.go
+++ b/action/filesystem/filesystem.go
@@ -187,12 +187,9 @@ func SaveCurrentRunTime(pathLastRun string) error {
 
 	// Create directory if needed
 	dir := filepath.Dir(pathLastRun)
-	err := CheckFileExists(dir)
-	if errors.Is(err, os.ErrNotExist) {
-		err = os.MkdirAll(dir, os.ModePerm)
-		if err != nil {
-			return err
-		}
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return err
 	}
 
 	// Write the current time into file

--- a/action/go.mod
+++ b/action/go.mod
@@ -42,11 +42,14 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jedib0t/go-pretty/v6 v6.6.3 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect

--- a/action/go.sum
+++ b/action/go.sum
@@ -86,6 +86,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jedib0t/go-pretty/v6 v6.6.3 h1:nGqgS0tgIO1Hto47HSaaK4ac/I/Bu7usmdD3qvs0WvM=
+github.com/jedib0t/go-pretty/v6 v6.6.3/go.mod h1:zbn98qrYlh95FIhwwsbIip0LYpwSG8SUOScs+v9/t0E=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -97,6 +99,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
@@ -109,6 +113,8 @@ github.com/plus3it/gorecurcopy v0.0.1 h1:H7AgvM0N/uIo7o1PQRlewEGQ92BNr7DqbPy5lnR
 github.com/plus3it/gorecurcopy v0.0.1/go.mod h1:NvVTm4RX68A1vQbHmHunDO4OtBLVroT6CrsiqAzNyJA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=

--- a/action/main.go
+++ b/action/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/9elements/firmware-action/action/recipes"
 	"github.com/alecthomas/kong"
 	"github.com/go-git/go-git/v5"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/sethvargo/go-githubactions"
 )
 
@@ -133,8 +134,11 @@ submodule_out:
 		recipes.Execute,
 	)
 
-	// Print overview
-	summary := "Build summary:"
+	// Pretty table
+	summaryTable := table.NewWriter()
+	summaryTable.AppendHeader(table.Row{"Module", "Status"})
+
+	// Create overview table
 	for _, item := range results {
 		result := ""
 		if item.BuildResult == nil {
@@ -144,9 +148,9 @@ submodule_out:
 		} else {
 			result = "Fail"
 		}
-		summary = fmt.Sprintf("%s\n%s: %s", summary, item.Name, result)
+		summaryTable.AppendRow([]interface{}{item.Name, result})
 	}
-	slog.Info(summary)
+	slog.Info(fmt.Sprintf("Build summary:\n%s", summaryTable.Render()))
 
 	if err == nil {
 		slog.Info("Build finished successfully")

--- a/action/main.go
+++ b/action/main.go
@@ -139,8 +139,8 @@ submodule_out:
 		result := ""
 		if item.BuildResult == nil {
 			result = "Success"
-		} else if errors.Is(item.BuildResult, recipes.ErrBuildSkipped) {
-			result = "Skipped"
+		} else if errors.Is(item.BuildResult, recipes.ErrBuildUpToDate) {
+			result = "Up-to-date"
 		} else {
 			result = "Fail"
 		}

--- a/action/recipes/config.go
+++ b/action/recipes/config.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	// ErrVerboseJSON is raised when JSONVerboseError can't find location of problem in JSON configuration file
-	ErrVerboseJSON     = errors.New("unable to pinpoint the problem in JSON file")
+	ErrVerboseJSON = errors.New("unable to pinpoint the problem in JSON file")
 	// ErrEnvVarUndefined is raised when undefined environment variable is found in JSON configuration file
 	ErrEnvVarUndefined = errors.New("environment variable used in JSON file is not present in the environment")
 )

--- a/action/recipes/config.go
+++ b/action/recipes/config.go
@@ -155,6 +155,20 @@ func (opts CommonOpts) GetOutputDir() string {
 	return opts.OutputDir
 }
 
+// GetSources returns slice of paths to all sources which are used for build
+func (opts CommonOpts) GetSources() []string {
+	sources := []string{}
+
+	// Repository path
+	sources = append(sources, opts.RepoPath)
+
+	// Input files and directories
+	sources = append(sources, opts.InputDirs[:]...)
+	sources = append(sources, opts.InputFiles[:]...)
+
+	return sources
+}
+
 // Config is for storing parsed configuration file
 type Config struct {
 	// defined in coreboot.go
@@ -201,6 +215,7 @@ type FirmwareModule interface {
 	GetContainerOutputDirs() []string
 	GetContainerOutputFiles() []string
 	GetOutputDir() string
+	GetSources() []string
 	buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) (*dagger.Container, error)
 }
 

--- a/action/recipes/recipes.go
+++ b/action/recipes/recipes.go
@@ -152,12 +152,10 @@ func Execute(ctx context.Context, target string, config *Config, interactive boo
 	// Find requested target
 	modules := config.AllModules()
 	if _, ok := modules[target]; ok {
-		// Check if output artifacts already exist
-		for _, artifact := range *modules[target].GetArtifacts() {
-			if _, err := os.Stat(artifact.HostPath); err == nil {
-				slog.Warn(fmt.Sprintf("Output directory for '%s' already exists, skipping build", target))
-				return ErrBuildSkipped
-			}
+		if _, err := os.Stat(modules[target].GetOutputDir()); err == nil {
+		// Check if output directory already exist
+			slog.Warn(fmt.Sprintf("Output directory for '%s' already exists, skipping build", target))
+			return ErrBuildSkipped
 		}
 
 		// Check if all outputs of required modules exist

--- a/action/recipes/recipes.go
+++ b/action/recipes/recipes.go
@@ -169,12 +169,9 @@ func IsDirEmpty(path string) (bool, error) {
 // func Execute(ctx context.Context, target string, config *Config, interactive bool, bulldozeMode bool) error {
 func Execute(ctx context.Context, target string, config *Config, interactive bool) error {
 	// Prep
-	_, err := os.Stat(TimestampsDir)
+	err := os.MkdirAll(TimestampsDir, os.ModePerm)
 	if err != nil {
-		err = os.MkdirAll(TimestampsDir, os.ModePerm)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	// Find requested target

--- a/action/recipes/recipes_test.go
+++ b/action/recipes/recipes_test.go
@@ -4,6 +4,7 @@ package recipes
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"dagger.io/dagger"
@@ -95,10 +96,18 @@ func TestExecuteSkipAndMissing(t *testing.T) {
 	assert.ErrorIs(t, err, ErrDependencyOutputMissing)
 
 	// Create the output directory
+	// Should build because the directory is empty
 	err = os.Mkdir(outputDir, os.ModePerm)
 	assert.NoError(t, err)
+	err = Execute(ctx, target, &myConfig, interactive)
+	assert.ErrorIs(t, err, ErrDependencyOutputMissing)
 
-	// Since there is now existing output directory, it should skip the build
+	// Create file inside output directory
+	myfile, err := os.Create(filepath.Join(outputDir, "dummy.txt"))
+	assert.NoError(t, err)
+	myfile.Close()
+
+	// Since there is now existing non-empty output directory, it should skip the build
 	err = Execute(ctx, target, &myConfig, interactive)
 	assert.ErrorIs(t, err, ErrBuildSkipped)
 }

--- a/action/recipes/recipes_test.go
+++ b/action/recipes/recipes_test.go
@@ -4,7 +4,6 @@ package recipes
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"dagger.io/dagger"
@@ -101,15 +100,6 @@ func TestExecuteSkipAndMissing(t *testing.T) {
 	assert.NoError(t, err)
 	err = Execute(ctx, target, &myConfig, interactive)
 	assert.ErrorIs(t, err, ErrDependencyOutputMissing)
-
-	// Create file inside output directory
-	myfile, err := os.Create(filepath.Join(outputDir, "dummy.txt"))
-	assert.NoError(t, err)
-	myfile.Close()
-
-	// Since there is now existing non-empty output directory, it should skip the build
-	err = Execute(ctx, target, &myConfig, interactive)
-	assert.ErrorIs(t, err, ErrBuildSkipped)
 }
 
 func executeDummy(_ context.Context, _ string, _ *Config, _ bool) error {

--- a/action/recipes/recipes_test.go
+++ b/action/recipes/recipes_test.go
@@ -62,9 +62,9 @@ func TestExecuteSkipAndMissing(t *testing.T) {
 
 	// Create configuration
 	const target = "dummy"
-	const outputDir = "output-coreboot"
+	const outputDir = "output-coreboot/"
 	const depends = "pre-dummy"
-	const outputDir2 = "output-coreboot2"
+	const outputDir2 = "output-coreboot2/"
 	myConfig := Config{
 		Coreboot: map[string]CorebootOpts{
 			target: {


### PR DESCRIPTION
- few fixes (mostly small stuff)
- speed up filesystem.DirTree (I just happened to stumble upon it)
- add functions to detect changes in files
  - add new filesystem functions which can detect changes in files base on time-stamps
  - since we work with large projects, such as Linux Kernel, this detection should be as fast as possible
  - to make it fast, we solely rely on time, no hashing
  - the idea is that firmware-action will create a time-stamp file at the end of each execution (for each target)
  - at the start of each execution firmware-action will load time-stamp file from previous execution and check if any file in sources is newer that the saved time-stamp
  - the detection function is lazy, and will return on first positive match
  - if the no file in sources is newer, target should be considered up-to-date and skipped
- add the ability to detect changes in sources
- in addition, the dagger setup was moved so now the loop for up-to-date module is much faster
- prettify summary table

Summary before:
```
[INFO   ] Build summary:
uroot-example: Skipped
linux-example-with-uroot: Skipped
coreboot-example-with-linuxboot: Skipped
```

Summary now:
```
[INFO   ] Build summary:
+---------------------------------+------------+
| MODULE                          | STATUS     |
+---------------------------------+------------+
| uroot-example                   | Up-to-date |
| linux-example-with-uroot        | Up-to-date |
| coreboot-example-with-linuxboot | Up-to-date |
+---------------------------------+------------+
```

fixes #441 