### PR TITLE
chore(dependabot): split updates for golang

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,6 @@ updates:
     schedule:
       interval: 'daily'
       time: '00:00'
-    groups:
-      golang:
-        update-types:
-          - 'minor'
-          - 'patch'
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"


### PR DESCRIPTION
- we had some issues with goilang updates when one faulty package would block updating another