### PR TITLE
fix(ci): stop scheduled docker container builds

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -17,9 +17,6 @@ on:
       - 'docker/**'
       - 'tests/**'
   release:
-  schedule:
-    # First day of the month at midnight
-    - cron: '0 0 1 * 0'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
- I think that the scheduled runs might be messing up the containers in the GitHub registry
- we have a problem that multiple containers are not possible to download, error says "manifest unknown"
- this might be the cause, but not sure yet
- it should be fine to build the containers only once and never touch them even again