### PR TITLE
feat: coreboot git describe

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -46,6 +46,7 @@
     "HEALTHCHECK",
     "Hadolint",
     "IPXE",
+    "KERNELVERSION",
     "NOTSET",
     "REPOPATH",
     "TARGETARCH",

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 .coverage
-.task
 .example_runs
+.task
+bin/
 cmd/firmware-action/coverage.html
 cmd/firmware-action/coverage.out
-bin/
+cmd/firmware-action/recipes/__tmp_files__/
+docker/coreboot/coreboot-*
 megalinter-reports
 node_modules
-cmd/firmware-action/recipes/__tmp_files__/
 output-*/
-docker/coreboot/coreboot-*

--- a/cmd/firmware-action/environment/environment.go
+++ b/cmd/firmware-action/environment/environment.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+// Package environment for is interacting with environment variables
+package environment
+
+import (
+	"os"
+)
+
+// FetchEnvVars when provided with list of environment variables is to
+// return a map of variables and values for those that exist in the environment
+func FetchEnvVars(variables []string) map[string]string {
+	result := make(map[string]string)
+
+	for _, variable := range variables {
+		value, exists := os.LookupEnv(variable)
+		if exists {
+			result[variable] = value
+		}
+	}
+
+	return result
+}

--- a/cmd/firmware-action/environment/environment_test.go
+++ b/cmd/firmware-action/environment/environment_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+// Package environment
+package environment
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateConfig(t *testing.T) {
+	testCases := []struct {
+		name              string
+		envCreate         map[string]string
+		envSearchFor      []string
+		envExpectedResult map[string]string
+	}{
+		{
+			name:              "no env vars created, no found",
+			envCreate:         map[string]string{},
+			envSearchFor:      []string{"MY_VAR"},
+			envExpectedResult: map[string]string{},
+		},
+		{
+			name: "one created, one found",
+			envCreate: map[string]string{
+				"MY_VAR": "my_val",
+			},
+			envSearchFor: []string{"MY_VAR"},
+			envExpectedResult: map[string]string{
+				"MY_VAR": "my_val",
+			},
+		},
+		{
+			name: "some created, some found",
+			envCreate: map[string]string{
+				"MY_VAR":  "my_val",
+				"MY_VAR2": "my_val2",
+			},
+			envSearchFor: []string{"MY_VAR"},
+			envExpectedResult: map[string]string{
+				"MY_VAR": "my_val",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for key, value := range tc.envCreate {
+				os.Setenv(key, value)
+				defer os.Unsetenv(key)
+				fmt.Printf("Setting %s = %s\n", key, value)
+			}
+
+			result := FetchEnvVars(tc.envSearchFor)
+
+			assert.Equal(t, tc.envExpectedResult, result)
+		})
+	}
+}

--- a/cmd/firmware-action/filesystem/git.go
+++ b/cmd/firmware-action/filesystem/git.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+
+// Package filesystem / git implements git-related commands
+package filesystem
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// gitRun is generic function to execute any git command in sub-directory
+func gitRun(subdir string, command []string) (string, error) {
+	// subdir is relative to current working directory
+
+	// Get current working directory
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	// Change current working directory into the repository / submodule
+	subdirPath := filepath.Join(pwd, subdir)
+	defer os.Chdir(pwd) // nolint:errcheck
+	err = os.Chdir(subdirPath)
+	if err != nil {
+		slog.Error(
+			fmt.Sprintf("Failed to change current working directory to '%s'", subdirPath),
+			slog.Any("error", err),
+		)
+		return "", err
+	}
+
+	// Run git describe
+	cmd := exec.Command(command[0], command[1:]...)
+	describe, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Error(
+			fmt.Sprintf("Failed to run git command in '%s'", subdirPath),
+			slog.Any("error", err),
+		)
+		return "", err
+	}
+
+	return string(describe), nil
+}
+
+// GitDescribeCoreboot is coreboot-specific git describe command
+func GitDescribeCoreboot(repoPath string) (string, error) {
+	describe, err := gitRun(repoPath, []string{"git", "describe", "--abbrev=12", "--dirty", "--always"})
+	if err != nil {
+		return "", err
+	}
+
+	// Remove trailing newline
+	result := strings.TrimSpace(describe)
+
+	// Check validity of the returned string
+	pattern := regexp.MustCompile(`[\d\w]{13}(\-dirty)?`)
+	valid := pattern.MatchString(result)
+	if !valid {
+		slog.Warn(
+			fmt.Sprintf("Output of 'git describe' for '%s' seems to be invalid, output is: '%s'", repoPath, result),
+		)
+	}
+
+	return result, err
+}

--- a/cmd/firmware-action/filesystem/git_test.go
+++ b/cmd/firmware-action/filesystem/git_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+)
+
+func gitRepoPrepare(t *testing.T, tmpDir string) {
+	// Create empty git repository
+	repo, err := git.PlainInit(tmpDir, false)
+	assert.NoError(t, err)
+
+	// Create a worktree to interact with the repo
+	worktree, err := repo.Worktree()
+	assert.NoError(t, err)
+
+	// Create a simple text file for testing
+	filename := "README.md"
+	pathFile := filepath.Join(tmpDir, filename)
+	err = os.WriteFile(pathFile, []byte{}, 0o666)
+	assert.NoError(t, err)
+
+	// Commit the file (must be relative path)
+	_, err = worktree.Add(filename)
+	assert.NoError(t, err)
+
+	commitOpts := &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "john doe",
+			Email: "john.doe@example.com",
+			When:  time.Date(2025, 1, 1, 12, 30, 0, 0, time.UTC),
+		},
+	}
+	_, err = worktree.Commit("Initial commit", commitOpts)
+	assert.NoError(t, err)
+}
+
+func TestGitRun(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pwd, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(pwd) // nolint:errcheck
+	err = os.Chdir(tmpDir)
+	assert.NoError(t, err)
+
+	gitRepoPrepare(t, tmpDir)
+
+	// Test git status
+	stdout, err := gitRun("./", []string{"git", "status"})
+	assert.NoError(t, err)
+	assert.Equal(t, stdout, "On branch master\nnothing to commit, working tree clean\n")
+}
+
+func TestGitDescribeCoreboot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pwd, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(pwd) // nolint:errcheck
+	err = os.Chdir(tmpDir)
+	assert.NoError(t, err)
+
+	gitRepoPrepare(t, tmpDir)
+
+	// Test git status
+	describe, err := GitDescribeCoreboot("./")
+	assert.NoError(t, err)
+	assert.Equal(t, describe, "4eeb1eaf0c81")
+	// This magic value comes from manual execution of the test
+	// Since the content, author and time of the commit are hard-coded,
+	//   the commit hash is always the same
+}


### PR DESCRIPTION
The motivations behind this:
- coreboot likes to embed its source version into the compiled binary
- coreboot does that by calling `git describe ...`
- however with firmware-action we can assume people will include coreboot as git submodule, and thus when compiling coreboot in container the git commands will fail because of missing `.git` directory
- to fix this we will run manually the `git describe` command and then pass it in form of env variable into the container

The coreboot part `crebootPassEnvVars` is not tested now. I am too tired to look into unit-testing that right now (the supporting functions have unit tests).

I just ran the `firmware-action` on one project and tested it manually - it seems to work exactly as expected. Not sure if it is worth it to write unit-test.

@MDr164 if you think unit-test for the `crebootPassEnvVars` is a good idea, then I will make it tomorrow.

**TODO:**
- [x] Check for existence of `.coreboot-version` which should take precedence before auto-generated env var (should prevent creation of env var). Might be good idea to make a list of priorities in the comments.
- [ ] I will also look into implementing this (read as copy-pasting) for Linux kernel too.