### PR TITLE
fix(docker): install newer NodeJS into edk2 containers

### DIFF
--- a/docker/edk2/Dockerfile
+++ b/docker/edk2/Dockerfile
@@ -45,6 +45,9 @@ ENV WORKSPACE=$TOOLSDIR/Edk2
 RUN if [ "${TARGETARCH}" = 'amd64' ]; then \
         dpkg --add-architecture i386; \
     fi; \
+    wget --quiet -O nodesource_setup.sh https://deb.nodesource.com/setup_20.x && \
+        chmod +x nodesource_setup.sh && \
+        ./nodesource_setup.sh && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         ${PYTHON_PACKAGES} \


### PR DESCRIPTION
- some edk2 containers have NodeJS v16 or older, which are end-of-life
- so let's add NodeJS repository for NodeJS v20 LTS
- we could also do v18 LTS, but it is going to be end-of-life soon
- only edk2 is finicky, other containers should rather upgrade the use Ubuntu version if this problem arises

fixes #494 