### PR TITLE
fix(docker): downgrade NodeJS for udk2017

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -56,6 +56,7 @@ services:
         - PYTHON_VERSION=python2
         - GCC_CROSS_COMPILER_PACKAGES_ARM=gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi gcc-i686-linux-gnu
         - GCC_CROSS_COMPILER_PACKAGES_X86=gcc-i686-linux-gnu
+        - NODESOURCE=https://deb.nodesource.com/setup_16.x
       # NonOSI wasn't used in 2017
   edk2-stable202008:
     build:
@@ -69,6 +70,7 @@ services:
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202105:
     build:
       context: edk2
@@ -81,6 +83,7 @@ services:
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202111:
     build:
       context: edk2
@@ -93,6 +96,7 @@ services:
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   # Building UniversalPayload from this point on is likely ???
   edk2-stable202205:
     build:
@@ -107,6 +111,7 @@ services:
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202208:
     build:
       context: edk2
@@ -120,6 +125,7 @@ services:
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202211:
     build:
       context: edk2
@@ -132,6 +138,7 @@ services:
         - INTERMEDIATE_IMAGE=universalpayload
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202302:
     build:
       context: edk2
@@ -145,6 +152,7 @@ services:
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202305:
     build:
       context: edk2
@@ -158,6 +166,7 @@ services:
         - GCC_VERSION=9
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   # Since edk2-stable202305 the GCC_VERSION should be more flexible
   # https://github.com/tianocore/edk2/commit/0fc07b1c6a491fa1e81daed6cfc2ec33c8cac973
   edk2-stable202308:
@@ -173,6 +182,7 @@ services:
         - GCC_VERSION=12
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202311:
     build:
       context: edk2
@@ -186,6 +196,7 @@ services:
         - GCC_VERSION=12
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202402:
     build:
       context: edk2
@@ -199,6 +210,7 @@ services:
         - GCC_VERSION=12
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202405:
     build:
       context: edk2
@@ -212,6 +224,7 @@ services:
         - GCC_VERSION=12
         - PYTHON_PACKAGES=python-is-python3 python2 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   edk2-stable202408.01:
     build:
       context: edk2
@@ -225,6 +238,7 @@ services:
         - GCC_VERSION=13
         - PYTHON_PACKAGES=python-is-python3 python3
         - PYTHON_VERSION=python3
+        - NODESOURCE=https://deb.nodesource.com/setup_20.x
   #==================
   # linux
   #==================

--- a/docker/edk2/Dockerfile
+++ b/docker/edk2/Dockerfile
@@ -4,12 +4,14 @@
 ARG SOURCE_IMAGE=buildpack-deps:focal
 ARG INTERMEDIATE_IMAGE=base
 ARG TARGETARCH=amd64
+ARG NODESOURCE=https://deb.nodesource.com/setup_20.x
 
 #=============
 # "base" stage with all needed build dependencies
 FROM ${SOURCE_IMAGE} AS base
 
 ARG TARGETARCH
+ARG NODESOURCE
 
 ARG EDK2_VERSION=edk2-stable202008
 ENV EDK2_VERSION=$EDK2_VERSION
@@ -45,7 +47,7 @@ ENV WORKSPACE=$TOOLSDIR/Edk2
 RUN if [ "${TARGETARCH}" = 'amd64' ]; then \
         dpkg --add-architecture i386; \
     fi; \
-    wget --quiet -O nodesource_setup.sh https://deb.nodesource.com/setup_20.x && \
+    wget --quiet -O nodesource_setup.sh "${NODESOURCE}" && \
         chmod +x nodesource_setup.sh && \
         ./nodesource_setup.sh && \
     apt-get update && \


### PR DESCRIPTION
- NodeJS v20 requires libc6 version >= 2.28, but that is not possible with this old Ubuntu
- switching to newer Ubuntu is not a option either because of how fragile and snowflaky edk2 is
- updating libc6 is just a terrible idea, that means that udk2017 cannot run NodeJS v20
- ~~the best we can do is to run v18, which is end-of-life soon, but that is the best we can do~~
- **UPDATE: the best we can do v16, everything else is too new for this old Ubuntu**
- still, it is much better than v10 that the Ubuntu Bionic (18.04) ships with

fixes #500 