### PR TITLE
Fix/changelog

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -48,7 +48,8 @@ jobs:
           cargo install --locked cocogitto
       - name: Update changelog
         run: |
-          cog changelog > CHANGELOG.md
+          cog bump --auto --disable-bump-commit
+        # cog bump will create a new tag, but it does not get pushed in along with the new PR branch
 
       - name: Create pull request
         id: create_pr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased (c150bd1..7823b44)
+## v0.10.2 - 2024-12-19
 #### Build system
 - **(deps)** bump docs/src/firmware-action-example - (4d59952) - dependabot[bot]
 - **(deps)** bump github.com/jedib0t/go-pretty/v6 in /action - (9454cd6) - dependabot[bot]
@@ -12,7 +12,7 @@
 
 - - -
 
-## v0.10.1 - 2024-12-19
+## v0.10.1 - 2024-12-14
 #### Build system
 - **(deps)** bump golang.org/x/crypto from 0.30.0 to 0.31.0 in /action - (8e739ed) - dependabot[bot]
 - **(deps)** update dagger-io requirement in /.dagger-ci/daggerci - (fd6eae2) - dependabot[bot]
@@ -21,7 +21,7 @@
 
 - - -
 
-## v0.10.0 - 2024-12-19
+## v0.10.0 - 2024-12-11
 #### Bug Fixes
 - **(action)** skipping .git - (f57cc93) - AtomicFS
 - **(action)** check for existing non-empty output directory - (f1f9418) - AtomicFS
@@ -56,7 +56,7 @@
 
 - - -
 
-## v0.9.0 - 2024-12-19
+## v0.9.0 - 2024-12-03
 #### Build system
 - **(deps)** bump docs/src/firmware-action-example - (a91d6a9) - dependabot[bot]
 - **(deps)** bump github.com/alecthomas/kong - (8a4052d) - dependabot[bot]
@@ -80,7 +80,7 @@
 
 - - -
 
-## v0.8.1 - 2024-12-19
+## v0.8.1 - 2024-11-28
 #### Bug Fixes
 - **(ci)** next version calculation - (ce6e90f) - AtomicFS
 - **(docker)** udk2017 needs python2 - (c3c3f22) - AtomicFS
@@ -92,7 +92,7 @@
 
 - - -
 
-## v0.8.0 - 2024-12-19
+## v0.8.0 - 2024-11-27
 #### Bug Fixes
 - **(ci)** cache cleanup - (1a4af0c) - AtomicFS
 - **(ci)** run example tests on change in golang code - (b60076b) - AtomicFS
@@ -119,7 +119,7 @@
 
 - - -
 
-## v0.7.0 - 2024-12-19
+## v0.7.0 - 2024-11-22
 #### Bug Fixes
 - **(action)** infinite symlink issue - (3d9a259) - AtomicFS
 - **(action)** linux make defconfig file conflict - (50e1d3d) - AtomicFS
@@ -261,7 +261,7 @@
 
 - - -
 
-## v0.6.1 - 2024-12-19
+## v0.6.1 - 2024-08-27
 #### Bug Fixes
 - **(action/linux)** defconfig filename - (4b9e9d4) - AtomicFS
 #### Miscellaneous Chores
@@ -269,7 +269,7 @@
 
 - - -
 
-## v0.6.0 - 2024-12-19
+## v0.6.0 - 2024-08-26
 #### Bug Fixes
 - **(ci)** consolidate jobs - (a9e6b0d) - AtomicFS
 - **(dagger)** missing docker-compose - (6b41c2e) - AtomicFS
@@ -290,7 +290,7 @@
 
 - - -
 
-## v0.5.0 - 2024-12-19
+## v0.5.0 - 2024-08-01
 #### Bug Fixes
 - **(action)** remove unnecessary apostrophes - (f715557) - AtomicFS
 - **(action)** if statement using compile input - (77403bf) - AtomicFS
@@ -321,7 +321,7 @@
 
 - - -
 
-## v0.4.0 - 2024-12-19
+## v0.4.0 - 2024-07-30
 #### Bug Fixes
 - **(action)** broken InputDirs - (4ae3cba) - AtomicFS
 - **(action)** simplify u-root test - (ed3f45c) - AtomicFS
@@ -375,7 +375,7 @@
 
 - - -
 
-## v0.3.2 - 2024-12-19
+## v0.3.2 - 2024-07-11
 #### Features
 - **(action)** allow multi-module workspaces for u-root - (f54803d) - AtomicFS
 #### Miscellaneous Chores
@@ -383,7 +383,7 @@
 
 - - -
 
-## v0.3.1 - 2024-12-19
+## v0.3.1 - 2024-07-11
 #### Bug Fixes
 - **(again)** build docker containers on release - (2d33a7e) - AtomicFS
 #### Miscellaneous Chores
@@ -391,7 +391,7 @@
 
 - - -
 
-## v0.3.0 - 2024-12-19
+## v0.3.0 - 2024-07-11
 #### Bug Fixes
 - **(megalinter)** fix spelling - (99a6247) - AtomicFS
 - **(typo)** typo - (a5d9fb5) - AtomicFS
@@ -417,7 +417,7 @@
 
 - - -
 
-## v0.2.1 - 2024-12-19
+## v0.2.1 - 2024-04-12
 #### Bug Fixes
 - **(action)** fix issue 195 - (d8bc51a) - AtomicFS
 - **(action)** fix bin filename in Taskfile.yml - (5b20be4) - AtomicFS
@@ -499,7 +499,7 @@
 
 - - -
 
-## v0.2.0 - 2024-12-19
+## v0.2.0 - 2024-03-11
 #### Build system
 - **(deps)** bump the golang group in /action with 1 update - (d7e9dc8) - dependabot[bot]
 - **(deps)** update pytest-timeout requirement in /.dagger-ci/daggerci - (11045e2) - dependabot[bot]
@@ -514,7 +514,7 @@
 
 - - -
 
-## v0.1.2 - 2024-12-19
+## v0.1.2 - 2024-03-04
 #### Bug Fixes
 - **(commitlint)** add config increasing max line length - (38a005e) - AtomicFS
 - **(docker)** edk2 repositories were missing files - (4cf4603) - AtomicFS
@@ -564,13 +564,13 @@
 
 - - -
 
-## v0.1.1 - 2024-12-19
+## v0.1.1 - 2024-03-04
 #### Bug Fixes
 - **(action)** naming mistake in JSON config - (58ebf67) - AtomicFS
 
 - - -
 
-## v0.1.0 - 2024-12-19
+## v0.1.0 - 2024-01-31
 #### Bug Fixes
 - **(docker)** add cleanup commands - (b26acf4) - AtomicFS
 - guard queue with mutex in recipes.go - (b160e01) - Marvin Drees
@@ -592,7 +592,7 @@
 
 - - -
 
-## v0.0.1 - 2024-12-19
+## v0.0.1 - 2024-01-22
 #### Bug Fixes
 - **(Dockerfile)** add --no-cache-dir - (c116873) - Patrick Rudolph
 - **(Dockerfile)** add user to fix linter - (ebca447) - Patrick Rudolph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
+
+- - -
+
 ## v0.10.2 - 2024-12-19
 #### Build system
 - **(deps)** bump docs/src/firmware-action-example - (4d59952) - dependabot[bot]


### PR DESCRIPTION
Fixes #437 

Just made a [quick fork and tested this out](https://github.com/AtomicFS/firmware-action/actions/runs/12889195801/job/35935825428). Works just like intended.

The `cog bump` does create a tag, but it is not pushed along with the `release/vX.X.X` branch. Which is perfect. [Created PR no longer changes the dates](https://github.com/AtomicFS/firmware-action/pull/2/files) for all of the previous releases.