### PR TITLE
fix(ci): example runs on windows and macos

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -498,4 +498,9 @@ jobs:
           recursive: 'false'
           compile: ${{ needs.changes.outputs.compile }}
         env:
+          COREBOOT_VERSION: '4.19'
+          LINUX_VERSION: '6.9.9'
+          SYSTEM_ARCH: 'amd64'
+          EDK2_VERSION: 'edk2-stable202208'
+          GCC_TOOLCHAIN_VERSION: 'GCC'
           UROOT_VERSION: ${{ matrix.uroot-version }}


### PR DESCRIPTION
- while these fail normally, right now they are failing because of undefined environment variables
- this is easy to fix problem