### PR TITLE
chore(cmd): fixup logging in tests

### DIFF
--- a/cmd/firmware-action/environment/environment_test.go
+++ b/cmd/firmware-action/environment/environment_test.go
@@ -4,7 +4,6 @@
 package environment
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -51,7 +50,7 @@ func TestValidateConfig(t *testing.T) {
 			for key, value := range tc.envCreate {
 				os.Setenv(key, value)
 				defer os.Unsetenv(key)
-				fmt.Printf("Setting %s = %s\n", key, value)
+				t.Logf("Setting %s = %s\n", key, value)
 			}
 
 			result := FetchEnvVars(tc.envSearchFor)

--- a/cmd/firmware-action/recipes/config_test.go
+++ b/cmd/firmware-action/recipes/config_test.go
@@ -4,7 +4,6 @@
 package recipes
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -116,7 +115,7 @@ func TestConfigReadAndWrite(t *testing.T) {
 	// Compare
 	equal := cmp.Equal(&configOriginal, configNew)
 	if !equal {
-		fmt.Println(cmp.Diff(configOriginal, configNew))
+		t.Log(cmp.Diff(configOriginal, configNew))
 		assert.True(t, equal, "written and read configuration are not equal")
 	}
 }
@@ -156,8 +155,8 @@ func TestFindAllEnvVars(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			foundVars := FindAllEnvVars(tc.text)
-			fmt.Println(foundVars)
-			fmt.Println(tc.expectedEnvVars)
+			t.Log(foundVars)
+			t.Log(tc.expectedEnvVars)
 
 			assert.Equal(t, len(tc.expectedEnvVars), len(foundVars))
 			// If both slices are of zero length, then the comparison fails for whatever reason
@@ -258,7 +257,7 @@ func TestConfigEnvVars(t *testing.T) {
 			for key, value := range tc.envVars {
 				os.Setenv(key, value)
 				defer os.Unsetenv(key)
-				fmt.Printf("Setting %s = %s\n", key, value)
+				t.Logf("Setting %s = %s\n", key, value)
 			}
 
 			// Write and read config

--- a/cmd/firmware-action/recipes/coreboot_test.go
+++ b/cmd/firmware-action/recipes/coreboot_test.go
@@ -53,7 +53,7 @@ func TestCorebootProcessBlobs(t *testing.T) {
 
 			equal := cmp.Equal(tc.expected, output)
 			if !equal {
-				fmt.Println(cmp.Diff(tc.expected, output))
+				t.Log(cmp.Diff(tc.expected, output))
 				assert.True(t, equal, "processing blob parameters failed")
 			}
 		})
@@ -583,7 +583,7 @@ func TestCorebootSubmodule(t *testing.T) {
 			for key, value := range tc.envVars {
 				os.Setenv(key, value)
 				defer os.Unsetenv(key)
-				fmt.Printf("Setting %s = %s\n", key, value)
+				t.Logf("Setting %s = %s\n", key, value)
 			}
 
 			// Make version file if required

--- a/cmd/firmware-action/recipes/stitching_test.go
+++ b/cmd/firmware-action/recipes/stitching_test.go
@@ -57,7 +57,7 @@ func TestExtractSizeFromString(t *testing.T) {
 			result, err := ExtractSizeFromString(tc.stdout)
 			equal := cmp.Equal(tc.expected, result)
 			if !equal {
-				fmt.Println(cmp.Diff(tc.expected, result))
+				t.Log(cmp.Diff(tc.expected, result))
 				assert.True(t, equal, "failed to extract size of ROM from string")
 			}
 			assert.ErrorIs(t, err, tc.wantErr)
@@ -126,7 +126,7 @@ func TestStringToSizeMB(t *testing.T) {
 			result, err := StringToSizeMB(tc.text)
 			equal := cmp.Equal(tc.expected, result)
 			if !equal {
-				fmt.Println(cmp.Diff(tc.expected, result))
+				t.Log(cmp.Diff(tc.expected, result))
 				assert.True(t, equal, "failed to decipher size")
 			}
 			assert.ErrorIs(t, err, tc.wantErr)


### PR DESCRIPTION
- replace log.Print() and fmt.Print() with t.Log()

fixes #247 