### PR TITLE
ci(docker): stop removing old containers

### DIFF
--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -1,0 +1,71 @@
+---
+# Remove old containers
+
+name: container cleanup
+on:
+  workflow_dispatch
+
+env:
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+
+jobs:
+  get-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: get-matrix
+        id: get-matrix
+        run: |
+          # Disable SC2046: Quote this to prevent word splitting
+          # I can't quote this, just look at it
+          # shellcheck disable=SC2046
+          echo matrix=$( yq --input-format yaml --output-format json '.services | keys[]' docker/compose.yaml | sed 's/"//g' | jq -Rs 'split("\n") | del(.[-1])' | jq -c ) >> "${GITHUB_OUTPUT}"
+      - name: Check
+        run: |
+          jq . <<< '${{ steps.get-matrix.outputs.matrix }}'
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+
+  cleanup:
+    name: container_cleanup
+    runs-on: ubuntu-latest
+    needs:
+      - get-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # We have to use my own fork of actions/delete-package-versions at the moment
+      #   to have access to 'dry-run' and 'ignore-versions-include-tags' features
+      # We can switch to upstream whe following PRs get merged:
+      #   - [dry-run](https://github.com/actions/delete-package-versions/pull/119/commits)
+      #   - [tags](https://github.com/actions/delete-package-versions/pull/104
+      - name: Delete old packages
+        uses: AtomicFS/delete-package-versions@main
+        continue-on-error:
+          true
+          # we have continue-on-error because when I make a fork of this repo to debug something,
+          # the Docker containers would not build because this step fails to fetch existing containers
+          # (in fresh fork there are none)
+        with:
+          package-name: firmware-action/${{ matrix.dockerfile }}
+          package-type: container
+          min-versions-to-keep: 5
+          ignore-versions:
+            '^(main|latest|v(\d+\.?)+)$'
+            # ignore:
+            # - main
+            # - latest
+            # - vX
+            # - vX.X
+            # - vX.X.X
+          dry-run: false
+          ignore-versions-include-tags: true

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -291,33 +291,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      # We have to use my own fork of actions/delete-package-versions at the moment
-      #   to have access to 'dry-run' and 'ignore-versions-include-tags' features
-      # We can switch to upstream whe following PRs get merged:
-      #   - [dry-run](https://github.com/actions/delete-package-versions/pull/119/commits)
-      #   - [tags](https://github.com/actions/delete-package-versions/pull/104
-      - name: Delete old packages
-        uses: AtomicFS/delete-package-versions@main
-        continue-on-error:
-          true
-          # we have continue-on-error because when I make a fork of this repo to debug something,
-          # the Docker containers would not build because this step fails to fetch existing containers
-          # (in fresh fork there are none)
-        with:
-          package-name: firmware-action/${{ matrix.dockerfile }}
-          package-type: container
-          min-versions-to-keep: 5
-          ignore-versions:
-            '^(main|latest|v(\d+\.?)+)$'
-            # ignore:
-            # - main
-            # - latest
-            # - vX
-            # - vX.X
-            # - vX.X.X
-          dry-run: false
-          ignore-versions-include-tags: true
-
       - name: Setup python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
- currently have a issue with Docker being unable to pull some containers
- maybe there is a bug in this step for removing old contianers causing problems, we could try to temporarily remove it