### PR TITLE
ci(docker): increase git commit sha slug to 12 characters

### DIFF
--- a/.dagger-ci/daggerci/lib/git.py
+++ b/.dagger-ci/daggerci/lib/git.py
@@ -19,7 +19,10 @@ def git_get_latest_commit_sha_short() -> str:
     Assuming that current working directory is part of git repository,
     get the sha of latest commit and return it.
     """
-    return git_get_latest_commit_sha_long()[:7]
+    # Typical git short sha which is 8-characters long:
+    # return git_get_latest_commit_sha_long()[:7]
+    # 12-character long short sha:
+    return git_get_latest_commit_sha_long()[:11]
 
 
 def git_describe() -> str | None:

--- a/.dagger-ci/daggerci/tests/test_git.py
+++ b/.dagger-ci/daggerci/tests/test_git.py
@@ -20,7 +20,7 @@ def test__git_get_latest_commit_sha_long():
 
 
 def test__git_get_latest_commit_sha_short():
-    assert re.match(r"^[a-z\d]{7}$", git_get_latest_commit_sha_short())
+    assert re.match(r"^[a-z\d]{11}$", git_get_latest_commit_sha_short())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- we are still having some issues with Docker pulling containers, maybe increasing the short git commit sha form default 8 characters to 12 will improve things (it will certainly decrease the likelihood of collision)