### PR TITLE
feat(cmd): expose building contianers on the fly

### DIFF
--- a/cmd/firmware-action/container/container_test.go
+++ b/cmd/firmware-action/container/container_test.go
@@ -176,7 +176,7 @@ func TestSetup(t *testing.T) {
 			}
 
 			// Spin up container
-			container, err := Setup(ctx, client, &tc.opts, "")
+			container, err := Setup(ctx, client, &tc.opts)
 			assert.ErrorIs(t, err, tc.wantErr)
 			if err != nil {
 				// No need to continue on err
@@ -350,7 +350,7 @@ func TestGetArtifacts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 
-			container, err := Setup(ctx, client, &opts, "")
+			container, err := Setup(ctx, client, &opts)
 			assert.NoError(t, err)
 
 			// Run commands in container

--- a/cmd/firmware-action/recipes/config.go
+++ b/cmd/firmware-action/recipes/config.go
@@ -42,6 +42,7 @@ type CommonOpts struct {
 	// Can also be a absolute or relative path to Dockerfile to build the image on the fly.
 	// NOTE: Updating the sdk_version might result in different binaries using the
 	//   same source code.
+	// ANCHOR: CommonOptsSdkURLExamples
 	// Examples:
 	//   https://ghcr.io/9elements/firmware-action/coreboot_4.19:main
 	//   https://ghcr.io/9elements/firmware-action/coreboot_4.19:latest
@@ -51,6 +52,9 @@ type CommonOpts struct {
 	//   file://my-image/Dockerfile
 	//   file:///home/user/my-image/Dockerfile
 	//   file:///home/user/my-image/
+	// ANCHOR_END: CommonOptsSdkURLExamples
+	// NOTE:
+	//   'file://' path cannot contain '..'
 	// See https://github.com/orgs/9elements/packages
 	SdkURL string `json:"sdk_url" validate:"required"`
 

--- a/cmd/firmware-action/recipes/config.go
+++ b/cmd/firmware-action/recipes/config.go
@@ -39,12 +39,18 @@ type CommonOpts struct {
 	// Specifies the container toolchain tag to use when building the image.
 	// This has an influence on the IASL, GCC and host GCC version that is used to build
 	//   the target. You must match the source level and sdk_version.
+	// Can also be a absolute or relative path to Dockerfile to build the image on the fly.
 	// NOTE: Updating the sdk_version might result in different binaries using the
 	//   same source code.
 	// Examples:
 	//   https://ghcr.io/9elements/firmware-action/coreboot_4.19:main
 	//   https://ghcr.io/9elements/firmware-action/coreboot_4.19:latest
 	//   https://ghcr.io/9elements/firmware-action/edk2-stable202111:latest
+	//   file://./my-image/Dockerfile
+	//   file://./my-image/
+	//   file://my-image/Dockerfile
+	//   file:///home/user/my-image/Dockerfile
+	//   file:///home/user/my-image/
 	// See https://github.com/orgs/9elements/packages
 	SdkURL string `json:"sdk_url" validate:"required"`
 
@@ -222,7 +228,7 @@ type FirmwareModule interface {
 	GetContainerOutputFiles() []string
 	GetOutputDir() string
 	GetSources() []string
-	buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error
+	buildFirmware(ctx context.Context, client *dagger.Client) error
 }
 
 // ===========

--- a/cmd/firmware-action/recipes/coreboot.go
+++ b/cmd/firmware-action/recipes/coreboot.go
@@ -248,7 +248,7 @@ func corebootProcessBlobs(opts CorebootBlobs) ([]BlobDef, error) {
 }
 
 // buildFirmware builds coreboot with all blobs and stuff
-func (opts CorebootOpts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
+func (opts CorebootOpts) buildFirmware(ctx context.Context, client *dagger.Client) error {
 	// Spin up container
 	containerOpts := container.SetupOpts{
 		ContainerURL:      opts.SdkURL,
@@ -259,7 +259,7 @@ func (opts CorebootOpts) buildFirmware(ctx context.Context, client *dagger.Clien
 		InputDirs:         opts.InputDirs,
 		InputFiles:        opts.InputFiles,
 	}
-	myContainer, err := container.Setup(ctx, client, &containerOpts, dockerfileDirectoryPath)
+	myContainer, err := container.Setup(ctx, client, &containerOpts)
 	if err != nil {
 		slog.Error(
 			"Failed to start a container",

--- a/cmd/firmware-action/recipes/coreboot_test.go
+++ b/cmd/firmware-action/recipes/coreboot_test.go
@@ -300,7 +300,7 @@ func TestCorebootBuild(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			// Try to build coreboot
-			err = tc.corebootOptions.buildFirmware(ctx, client, "")
+			err = tc.corebootOptions.buildFirmware(ctx, client)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts
@@ -311,7 +311,7 @@ func TestCorebootBuild(t *testing.T) {
 
 			if tc.wantErr == nil {
 				// Check coreboot version
-				err = tc.universalOptions.buildFirmware(ctx, client, "")
+				err = tc.universalOptions.buildFirmware(ctx, client)
 				assert.ErrorIs(t, err, tc.wantErr)
 
 				// Check file with coreboot version exists
@@ -592,7 +592,7 @@ func TestCorebootSubmodule(t *testing.T) {
 			}
 
 			// Try to build coreboot
-			err = tc.corebootOptions.buildFirmware(ctx, client, "")
+			err = tc.corebootOptions.buildFirmware(ctx, client)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts
@@ -602,7 +602,7 @@ func TestCorebootSubmodule(t *testing.T) {
 			}
 
 			// Check coreboot version
-			err = tc.universalOptions.buildFirmware(ctx, client, "")
+			err = tc.universalOptions.buildFirmware(ctx, client)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check file with coreboot version exists

--- a/cmd/firmware-action/recipes/edk2.go
+++ b/cmd/firmware-action/recipes/edk2.go
@@ -84,7 +84,7 @@ func (opts Edk2Opts) GetSources() []string {
 }
 
 // buildFirmware builds edk2 or Intel FSP
-func (opts Edk2Opts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
+func (opts Edk2Opts) buildFirmware(ctx context.Context, client *dagger.Client) error {
 	envVars := map[string]string{
 		"WORKSPACE":      ContainerWorkDir,
 		"EDK_TOOLS_PATH": "/tools/Edk2/BaseTools",
@@ -101,7 +101,7 @@ func (opts Edk2Opts) buildFirmware(ctx context.Context, client *dagger.Client, d
 		InputFiles:        opts.InputFiles,
 	}
 
-	myContainer, err := container.Setup(ctx, client, &containerOpts, dockerfileDirectoryPath)
+	myContainer, err := container.Setup(ctx, client, &containerOpts)
 	if err != nil {
 		slog.Error(
 			"Failed to start a container",

--- a/cmd/firmware-action/recipes/edk2_test.go
+++ b/cmd/firmware-action/recipes/edk2_test.go
@@ -24,14 +24,6 @@ func TestEdk2(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Chdir(pwd) // nolint:errcheck
 
-	// Use "" if you want to test containers from github package registry
-	// Use "../../container/edk2" if you want to test containers built fresh from Dockerfile
-	dockerfilePath := ""
-	if false {
-		dockerfilePath, err = filepath.Abs("../../container/edk2")
-		assert.NoError(t, err)
-	}
-
 	common := CommonOpts{
 		SdkURL:              "ghcr.io/9elements/firmware-action/edk2-stable202105:main",
 		OutputDir:           "output",
@@ -107,7 +99,7 @@ func TestEdk2(t *testing.T) {
 			tc.edk2Options.OutputDir = outputPath
 
 			// Try to build edk2
-			err = tc.edk2Options.buildFirmware(ctx, client, dockerfilePath)
+			err = tc.edk2Options.buildFirmware(ctx, client)
 			assert.NoError(t, err)
 
 			// Check artifacts

--- a/cmd/firmware-action/recipes/linux.go
+++ b/cmd/firmware-action/recipes/linux.go
@@ -82,7 +82,7 @@ func (opts LinuxOpts) GetSources() []string {
 // buildFirmware builds linux kernel
 //
 //	docs: https://www.kernel.org/doc/html/latest/kbuild/index.html
-func (opts LinuxOpts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
+func (opts LinuxOpts) buildFirmware(ctx context.Context, client *dagger.Client) error {
 	// Spin up container
 	containerOpts := container.SetupOpts{
 		ContainerURL:      opts.SdkURL,
@@ -93,7 +93,7 @@ func (opts LinuxOpts) buildFirmware(ctx context.Context, client *dagger.Client, 
 		InputDirs:         opts.InputDirs,
 		InputFiles:        opts.InputFiles,
 	}
-	myContainer, err := container.Setup(ctx, client, &containerOpts, dockerfileDirectoryPath)
+	myContainer, err := container.Setup(ctx, client, &containerOpts)
 	if err != nil {
 		slog.Error(
 			"Failed to start a container",

--- a/cmd/firmware-action/recipes/linux_test.go
+++ b/cmd/firmware-action/recipes/linux_test.go
@@ -28,14 +28,6 @@ func TestLinux(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Chdir(pwd) // nolint:errcheck
 
-	// Use "" if you want to test containers from github package registry
-	// Use "../../container/linux" if you want to test containers built fresh from Dockerfile
-	dockerfilePath := ""
-	if false {
-		dockerfilePath, err = filepath.Abs("../../container/linux")
-		assert.NoError(t, err)
-	}
-
 	linuxOpts := LinuxOpts{
 		CommonOpts: CommonOpts{
 			OutputDir: "output",
@@ -151,7 +143,7 @@ func TestLinux(t *testing.T) {
 			myLinuxOpts.OutputDir = outputPath
 
 			// Try to build linux kernel
-			err = myLinuxOpts.buildFirmware(ctx, client, dockerfilePath)
+			err = myLinuxOpts.buildFirmware(ctx, client)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts

--- a/cmd/firmware-action/recipes/recipes.go
+++ b/cmd/firmware-action/recipes/recipes.go
@@ -244,7 +244,7 @@ func Execute(ctx context.Context, target string, config *Config) error {
 		defer client.Close()
 
 		// Build the module
-		err = modules[target].buildFirmware(ctx, client, "")
+		err = modules[target].buildFirmware(ctx, client)
 		if err == nil {
 			// On success update the timestamp
 			_ = filesystem.SaveCurrentRunTime(timestampFile)

--- a/cmd/firmware-action/recipes/stitching.go
+++ b/cmd/firmware-action/recipes/stitching.go
@@ -161,7 +161,7 @@ func ifdtoolCmd(platform string, arguments []string) []string {
 }
 
 // buildFirmware builds coreboot with all blobs and stuff
-func (opts FirmwareStitchingOpts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
+func (opts FirmwareStitchingOpts) buildFirmware(ctx context.Context, client *dagger.Client) error {
 	// Check that all files have unique filenames (they are copied into the same dir)
 	copiedFiles := map[string]string{}
 	for _, entry := range opts.IfdtoolEntries {
@@ -184,7 +184,7 @@ func (opts FirmwareStitchingOpts) buildFirmware(ctx context.Context, client *dag
 		MountHostDir:      opts.RepoPath,
 		WorkdirContainer:  ContainerWorkDir,
 	}
-	myContainer, err := container.Setup(ctx, client, &containerOpts, dockerfileDirectoryPath)
+	myContainer, err := container.Setup(ctx, client, &containerOpts)
 	if err != nil {
 		slog.Error(
 			"Failed to start a container",

--- a/cmd/firmware-action/recipes/stitching_test.go
+++ b/cmd/firmware-action/recipes/stitching_test.go
@@ -364,7 +364,7 @@ func TestStitching(t *testing.T) {
 			assert.NoError(t, err)
 			defer client.Close()
 
-			err = tc.stitchingOpts.buildFirmware(ctx, client, "")
+			err = tc.stitchingOpts.buildFirmware(ctx, client)
 			assert.ErrorIs(t, err, tc.wantErr)
 			if tc.wantErr != nil {
 				return

--- a/cmd/firmware-action/recipes/universal.go
+++ b/cmd/firmware-action/recipes/universal.go
@@ -49,7 +49,7 @@ func (opts UniversalOpts) GetArtifacts() *[]container.Artifacts {
 }
 
 // buildFirmware builds (or rather executes) universal command module
-func (opts UniversalOpts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
+func (opts UniversalOpts) buildFirmware(ctx context.Context, client *dagger.Client) error {
 	// Spin up container
 	containerOpts := container.SetupOpts{
 		ContainerURL:      opts.SdkURL,
@@ -60,7 +60,7 @@ func (opts UniversalOpts) buildFirmware(ctx context.Context, client *dagger.Clie
 		InputDirs:         opts.InputDirs,
 		InputFiles:        opts.InputFiles,
 	}
-	myContainer, err := container.Setup(ctx, client, &containerOpts, dockerfileDirectoryPath)
+	myContainer, err := container.Setup(ctx, client, &containerOpts)
 	if err != nil {
 		slog.Error(
 			"Failed to start a container",

--- a/cmd/firmware-action/recipes/universal_test.go
+++ b/cmd/firmware-action/recipes/universal_test.go
@@ -73,7 +73,7 @@ func TestUniversal(t *testing.T) {
 			myUniversalOpts.OutputDir = outputPath
 
 			// Try to build universal
-			err = myUniversalOpts.buildFirmware(ctx, client, "")
+			err = myUniversalOpts.buildFirmware(ctx, client)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts

--- a/cmd/firmware-action/recipes/uroot.go
+++ b/cmd/firmware-action/recipes/uroot.go
@@ -49,7 +49,7 @@ func (opts URootOpts) GetArtifacts() *[]container.Artifacts {
 }
 
 // buildFirmware builds u-root
-func (opts URootOpts) buildFirmware(ctx context.Context, client *dagger.Client, dockerfileDirectoryPath string) error {
+func (opts URootOpts) buildFirmware(ctx context.Context, client *dagger.Client) error {
 	// Spin up container
 	containerOpts := container.SetupOpts{
 		ContainerURL:      opts.SdkURL,
@@ -60,7 +60,7 @@ func (opts URootOpts) buildFirmware(ctx context.Context, client *dagger.Client, 
 		InputDirs:         opts.InputDirs,
 		InputFiles:        opts.InputFiles,
 	}
-	myContainer, err := container.Setup(ctx, client, &containerOpts, dockerfileDirectoryPath)
+	myContainer, err := container.Setup(ctx, client, &containerOpts)
 	if err != nil {
 		slog.Error(
 			"Failed to start a container",

--- a/cmd/firmware-action/recipes/uroot_test.go
+++ b/cmd/firmware-action/recipes/uroot_test.go
@@ -98,7 +98,7 @@ func TestURoot(t *testing.T) {
 			myURootOpts.OutputDir = outputPath
 
 			// Try to build u-root initramfs
-			err = myURootOpts.buildFirmware(ctx, client, "")
+			err = myURootOpts.buildFirmware(ctx, client)
 			assert.ErrorIs(t, err, tc.wantErr)
 
 			// Check artifacts

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,14 +14,15 @@
         - [Get firmware-action](firmware-action/get_started/04_get_firmware_action.md)
         - [Run firmware-action locally](firmware-action/get_started/05_run_firmware_action.md)
         - [Run firmware-action in CI](firmware-action/get_started/06_run_in_ci.md)
-    - [Interactive debugging](firmware-action/interactive.md)
     - [TLDR; Usage](firmware-action/usage.md)
         - [Local system](firmware-action/usage_local.md)
         - [GitHub CI](firmware-action/usage_github.md)
     - [Configuration](firmware-action/config.md)
-    - [Offline usage](firmware-action/offline_usage.md)
     - [Troubleshooting](firmware-action/troubleshooting.md)
     - [Features](firmware-action/features.md)
+        - [Build Docker container on the fly](firmware-action/build_dockerfile_on_the_fly.md)
+        - [Interactive debugging](firmware-action/interactive.md)
+        - [Offline usage](firmware-action/offline_usage.md)
 
 ---
 

--- a/docs/src/firmware-action/build_dockerfile_on_the_fly.md
+++ b/docs/src/firmware-action/build_dockerfile_on_the_fly.md
@@ -1,0 +1,25 @@
+# Build Docker container on the fly
+
+As already mentioned in [Configuration/common](config.md#common) section, firmware-action can build a Docker container on the fly when provided with `Dockerfile`.
+
+The `sdk_url` field in configuration file accepts both URL and file-path. If file-path is provided, the container will be build and used (subsequent runs will no rebuild the container unless there changes were made to the `Dockerfile`).
+
+The file-path can be a absolute or relative path to `Dockerfile` (or directory in which `Dockerfile` is) to build the image on the fly.
+
+```admonish example title="Accepted values"
+~~~
+{{#include ../../../cmd/firmware-action/recipes/config.go:CommonOptsSdkURLExamples}}
+~~~
+```
+
+```admonish warning
+`file://` path cannot contain `..`
+```
+
+```admonish
+Docker engine assumes single `Dockerfile` per directory, hence it requires path to the parent directory in which the `Dockerfile` resides (not to the file itself). For user-comfort, firmware-action accepts both path to parent directory and path to the file.
+
+If the path contains the `Dockerfile` as last element, it will be removed before passed over to Docker engine.
+
+Meaning that if user provides `file:///home/user/my-image/Dockerfile`, the Docker engine will receive `file:///home/user/my-image/`.
+```

--- a/docs/src/firmware-action/features.md
+++ b/docs/src/firmware-action/features.md
@@ -1,6 +1,8 @@
 # Features
 
+- [Build Docker container on the fly](firmware-action/build_dockerfile_on_the_fly.md)
 - [Environment variables in JSON configuration](./usage_github.md#parametric-builds-with-environment-variables)
-- [Recursive builds](./config.md#modules)
 - [Interactive mode](./interactive.md)
+- [Offline usage](./offline_usage.md)
+- [Recursive builds](./config.md#modules)
 


### PR DESCRIPTION
- for a while now there was a functionality to build Docker containers on the fly from Dockerfile, but this feature was not exposed to the user
- this patch exposes the feature
- it will not work will with our Dockerfiles out of the box because they are meant to be used with accompanying Docker Compose file, so using one of our Dockerfiles would require to edit it (just replace default ARG values with desired ones)

fixes #163 