### PR TITLE
feat(cmd): warning about using discontinued containers

### DIFF
--- a/cmd/firmware-action/container/container.go
+++ b/cmd/firmware-action/container/container.go
@@ -111,6 +111,25 @@ func Setup(ctx context.Context, client *dagger.Client, opts *SetupOpts) (*dagger
 		if dockerfileDockerfilePattern.MatchString(opts.ContainerURL) {
 			dockerfileDirectoryPath = filepath.Dir(dockerfileDirectoryPath)
 		}
+	} else {
+		// Check for discontinued containers
+		listDiscontinued := []string{
+			`.*ghcr\.io\/9elements\/firmware\-action\/coreboot_4\.20(:.*)?$`,
+			`.*ghcr\.io\/9elements\/firmware\-action\/coreboot_4\.22(:.*)?$`,
+			`.*ghcr\.io\/9elements\/firmware\-action\/coreboot_24\.02(:.*)?$`,
+			`.*ghcr\.io\/9elements\/firmware\-action\/edk2\-stable202408(:.*)?$`,
+			`.*ghcr\.io\/9elements\/uefi:edk\-stable202208.*`,
+			`.*ghcr\.io\/9elements\/coreboot:4\.19.*`,
+		}
+		for _, discontinued := range listDiscontinued {
+			pattern := regexp.MustCompile(discontinued)
+			if pattern.MatchString(opts.ContainerURL) {
+				slog.Warn(
+					"Using discontinued container",
+					slog.String("suggestion", "The container will remain available, but will no longer receive any bug-fixes or updates. If you want maintained and up-to-date container, look at https://github.com/9elements/firmware-action#containers"),
+				)
+			}
+		}
 	}
 
 	// Setup container either from URL or build from Dockerfile

--- a/docs/src/docker/docker-compose.md
+++ b/docs/src/docker/docker-compose.md
@@ -84,3 +84,10 @@ In addition, there might be `VERIFICATION_TEST_*` variables. These are used insi
 - Add new entry into strategy matrix in `.github/workflows/docker-build-and-test.yml`
 - (optional) Add new strategy matrix in `.github/workflows/example.yml` examples
     - this requires adding new configuration file in `tests` directory
+- Add entry into a list of containers in `README.md`
+
+
+## Discontinuing container
+
+- Update entry in list of containers in `README.md`
+- Add new regex entry into `Setup()` function in `cmd/firmware-action/container/container.go` to warn about discontinued containers


### PR DESCRIPTION
- print a simple warning when people use discontinued containers
- the regex list should remain in sync with list in README.md

fixes #554 