### PR TITLE
fix(cmd): empty coreboot blob handling

### DIFF
--- a/cmd/firmware-action/recipes/coreboot.go
+++ b/cmd/firmware-action/recipes/coreboot.go
@@ -114,14 +114,16 @@ func (opts CorebootOpts) ProcessBlobs() ([]BlobDef, error) {
 	blobs := []BlobDef{}
 
 	for key, value := range opts.Blobs {
-		newBlob := BlobDef{
-			KconfigKey: key,
-			Path:       value,
-			// Blobs get renamed when moved to this string
-			DestinationFilename: filepath.Base(value),
-		}
+		if key != "" && value != "" {
+			newBlob := BlobDef{
+				KconfigKey: key,
+				Path:       value,
+				// Blobs get renamed when moved to this string
+				DestinationFilename: filepath.Base(value),
+			}
 
-		blobs = append(blobs, newBlob)
+			blobs = append(blobs, newBlob)
+		}
 	}
 	return blobs, nil
 }


### PR DESCRIPTION
- thanks to our JSON configuration supporting environment variables, it is possible that users will end up if configuration where blob key-value pair has empty value or key
- simply ignore pairs where either key or value is empty string