### PR TITLE
feat: add goreleaser linting check and replace hardcoded version strings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,3 +67,14 @@ jobs:
         with:
           version: latest
           working-directory: cmd/firmware-action
+
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check goreleaser configuration
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: check
+          workdir: cmd/firmware-action

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -32,12 +32,6 @@ jobs:
           noVersionBumpBehavior: patch
 
       # Bump version
-      - name: Update main.go
-        run: |
-          sed -i -E 's/const firmwareActionVersion = .*/const firmwareActionVersion = "${{ steps.semver.outputs.next }}"/g' cmd/firmware-action/main.go
-      - name: Update Taskfile.yml
-        run: |
-          sed -i -E "s/^  SEMVER: .*/  SEMVER: '${{ steps.semver.outputs.next }}'/g" Taskfile.yml
       - name: Update action.yml
         run: |
           sed -i -E "s/version=v[a-zA-Z0-9\.]+/version=${{ steps.semver.outputs.next }}/g" action.yml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,13 @@
 ---
 version: '3'
 vars:
-  SEMVER: 'v0.14.1'
+  VERSION:
+    sh: git describe --tags --always --abbrev=8 | sed -E 's/^v//g'
+    # strip the 'v' prefix to match behaviour of goreleaser
+  COMMIT:
+    sh: git rev-parse --short HEAD
+  DATE:
+    sh: date --rfc-3339=seconds | sed 's/ /T/' | sed 's/+/Z/'
   GOLANG_CODE_PATH: 'cmd/firmware-action'
 
 includes:
@@ -13,20 +19,20 @@ includes:
     taskfile: ./tests/Taskfile.yml
     optional: true
     vars:
-      SEMVER: '{{.SEMVER}}'
+      VERSION: 'v{{.VERSION}}'
 
 tasks:
   build-go-binary:
     desc: Template task to build a go binary
     dir: '{{.GOLANG_CODE_PATH}}'
     cmds:
-      - go build -ldflags="-s -w" -o ../../bin/firmware-action-{{OS}}-{{ARCH}}-{{.SEMVER}}
+      - go build -ldflags="-s -w -X main.version={{.VERSION}} -X main.commit={{.COMMIT}} -X main.date={{.DATE}}" -o ../../bin/firmware-action-{{OS}}-{{ARCH}}-v{{.VERSION}}
     env:
       CGO_ENABLED: 0
     sources:
       - ./**/*.go
     generates:
-      - ../../bin/firmware-action-{{OS}}-{{ARCH}}-{{.SEMVER}}
+      - ../../bin/firmware-action-{{OS}}-{{ARCH}}-v{{.VERSION}}
 
   lint:
     desc: Run the linters

--- a/cmd/firmware-action/.gitignore
+++ b/cmd/firmware-action/.gitignore
@@ -1,1 +1,3 @@
 action*
+# Added by goreleaser init:
+dist/

--- a/cmd/firmware-action/.goreleaser.yaml
+++ b/cmd/firmware-action/.goreleaser.yaml
@@ -6,7 +6,8 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
+
 dist: '../bin'
 project_name: 'firmware-action'
 
@@ -19,7 +20,7 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -31,4 +32,4 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']

--- a/cmd/firmware-action/main.go
+++ b/cmd/firmware-action/main.go
@@ -22,6 +22,12 @@ import (
 	"github.com/sethvargo/go-githubactions"
 )
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	logging.InitLogger(slog.LevelInfo)
 
@@ -33,8 +39,6 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-const firmwareActionVersion = "v0.14.1"
 
 // CLI (Command Line Interface) holds data from environment
 var CLI struct {
@@ -233,7 +237,9 @@ func parseCli() (string, error) {
 
 	case "version":
 		// Print version and exit
-		fmt.Println(firmwareActionVersion)
+		fmt.Printf("version: %s\n", version)
+		fmt.Printf("commit: %s\n", commit)
+		fmt.Printf("date: %s\n", date)
 		return "", nil
 
 	default:

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -43,7 +43,7 @@ tasks:
     internal: true
     cmds:
       - cp -f "../tests/linux_{{.LINUX_VERSION}}/linux.defconfig" "ci_defconfig"
-      - ../bin/firmware-action-linux-amd64-{{.SEMVER}} build --config="../tests/example_config__linux.json" --target=linux-example
+      - ../bin/firmware-action-linux-amd64-v{{.VERSION}} build --config="../tests/example_config__linux.json" --target=linux-example
     env:
       LINUX_VERSION: '{{.LINUX_VERSION}}'
       SYSTEM_ARCH: 'amd64'
@@ -88,7 +88,7 @@ tasks:
     cmds:
       - cp -f "../tests/uboot_{{.UBOOT_VERSION}}/uboot.defconfig" "uboot_defconfig"
       - ln -sf "uboot-{{.UBOOT_VERSION}}" u-boot
-      - ../bin/firmware-action-linux-amd64-{{.SEMVER}} build --config="../tests/example_config__uboot.json" --target=u-boot-example
+      - ../bin/firmware-action-linux-amd64-v{{.VERSION}} build --config="../tests/example_config__uboot.json" --target=u-boot-example
     env:
       UBOOT_VERSION: '{{.UBOOT_VERSION}}'
       SYSTEM_ARCH: 'arm64'


### PR DESCRIPTION
## Update goreleaser configuration
- update to v2
- NOTE: some options we were still using there were deprecated

## Replace hardcoded version strings
- goreleaser already passes version based on git describe as `ldflag` along with commit and date (source: https://goreleaser.com/cookbooks/using-main.version/)
- the main Taskfile now replicates the same exact behavior as goreleaser
- we no longer have to keep these hardcoded strings in sync
- when people build from source the version string is much more descriptive
