### PR TITLE
feat: delete container after use

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -551,6 +551,10 @@ jobs:
       - changes
       - skip-check
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        prune: ['true', 'false']
     if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') && needs.skip-check.outputs.changes == 'true' }}
     # Skip if pull_request_review on PR not made by a bot
     steps:
@@ -568,14 +572,14 @@ jobs:
           config: 'tests/example_config__depends.json'
           target: 'universal-example-B'
           recursive: 'true'
-          prune: 'true'
+          prune: ${{ matrix.prune }}
           compile: ${{ needs.changes.outputs.compile }}
 
       - name: Get artifacts
         uses: actions/upload-artifact@v4
         with:
           name: prune
-          path: output-universal-example-B
+          path: output-universal-example-B-${{ matrix.prune }}
           retention-days: 14
   # ANCHOR_END: example_build_prune
 

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -544,6 +544,41 @@ jobs:
           retention-days: 14
   # ANCHOR_END: example_build_universal
 
+  # Example of building with pruning enabled
+  # ANCHOR: example_build_prune
+  build-with-pruning:
+    needs:
+      - changes
+      - skip-check
+    runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') && needs.skip-check.outputs.changes == 'true' }}
+    # Skip if pull_request_review on PR not made by a bot
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: firmware-action
+        uses: ./
+        # uses: 9elements/firmware-action
+        with:
+          config: 'tests/example_config__depends.json'
+          target: 'universal-example-B'
+          recursive: 'true'
+          prune: 'true'
+          compile: ${{ needs.changes.outputs.compile }}
+
+      - name: Get artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prune
+          path: output-universal-example-B
+          retention-days: 14
+  # ANCHOR_END: example_build_prune
+
   # Example of running on non-Linux systems
   test-operating-systems:
     strategy:

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,12 @@ inputs:
       Build target recursively, with all of its dependencies.
     required: false
     default: 'false'
+  prune:
+    description: |
+      Remove Dagger container and its volumes after each module (only in recursive mode).
+      Enable this when building complex firmware stack in single job recursively and you are running out of disk space.
+    required: false
+    default: 'false'
   compile:
     description: |
       Compile the action from source instead of downloading pre-compiled binary from releases.
@@ -119,6 +125,7 @@ runs:
         INPUT_CONFIG: ${{ inputs.config }}
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_RECURSIVE: ${{ inputs.recursive }}
+        INPUT_PRUNE: ${{ inputs.prune }}
 
     - name: run_windows
       if: ${{ runner.os == 'Windows' }}
@@ -129,3 +136,4 @@ runs:
         INPUT_CONFIG: ${{ inputs.config }}
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_RECURSIVE: ${{ inputs.recursive }}
+        INPUT_PRUNE: ${{ inputs.prune }}

--- a/cmd/firmware-action/environment/environment.go
+++ b/cmd/firmware-action/environment/environment.go
@@ -21,3 +21,11 @@ func FetchEnvVars(variables []string) map[string]string {
 
 	return result
 }
+
+// DetectGithub function returns True when the execution environment is detected to be GitHub CI
+func DetectGithub() bool {
+	// Check for GitHub
+	// https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+	_, exists := os.LookupEnv("GITHUB_ACTIONS")
+	return exists
+}

--- a/cmd/firmware-action/main.go
+++ b/cmd/firmware-action/main.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/9elements/firmware-action/cmd/firmware-action/environment"
 	"github.com/9elements/firmware-action/cmd/firmware-action/filesystem"
 	"github.com/9elements/firmware-action/cmd/firmware-action/logging"
 	"github.com/9elements/firmware-action/cmd/firmware-action/recipes"
@@ -163,9 +164,7 @@ submodule_out:
 
 func getInputsFromEnvironment() (string, error) {
 	// Check for GitHub
-	// https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-	_, exists := os.LookupEnv("GITHUB_ACTIONS")
-	if exists {
+	if environment.DetectGithub() {
 		return parseGithub()
 	}
 

--- a/cmd/firmware-action/recipes/recipes_test.go
+++ b/cmd/firmware-action/recipes/recipes_test.go
@@ -250,6 +250,7 @@ func TestBuild(t *testing.T) {
 				ctx,
 				tc.target,
 				tc.recursive,
+				false, // do not prune
 				&tc.config,
 				executeDummy,
 			)
@@ -262,6 +263,7 @@ func TestBuild(t *testing.T) {
 			ctx,
 			"pizza",
 			recursive,
+			false, // do not prune
 			&testConfigDependencyHell,
 			executeDummy,
 		)

--- a/tests/example_config.json
+++ b/tests/example_config.json
@@ -17,6 +17,44 @@
       "input_files": null
     }
   },
+  "universal": {
+    "universal-example-A": {
+      "depends": null,
+      "sdk_url": "golang:latest",
+      "repo_path": "./",
+      "container_output_dirs": null,
+      "container_output_files": [
+        "test.txt"
+      ],
+      "output_dir": "output-universal-example-A/",
+      "input_dirs": null,
+      "input_files": null,
+      "container_input_dir": "inputs/",
+      "build_commands": [
+        "echo 'hello world'",
+        "touch test.txt"
+      ]
+    },
+    "universal-example-B": {
+      "depends": [
+        "universal-example-A"
+      ],
+      "sdk_url": "golang:latest",
+      "repo_path": "./",
+      "container_output_dirs": null,
+      "container_output_files": [
+        "test.txt"
+      ],
+      "output_dir": "output-universal-example-B/",
+      "input_dirs": null,
+      "input_files": null,
+      "container_input_dir": "inputs/",
+      "build_commands": [
+        "echo 'hello world'",
+        "touch test.txt"
+      ]
+    }
+  },
   "edk2": {
     "edk2-example": {
       "depends": null,

--- a/tests/example_config__depends.json
+++ b/tests/example_config__depends.json
@@ -1,0 +1,40 @@
+{
+  "universal": {
+    "universal-example-A": {
+      "depends": null,
+      "sdk_url": "golang:latest",
+      "repo_path": "./",
+      "container_output_dirs": null,
+      "container_output_files": [
+        "test.txt"
+      ],
+      "output_dir": "output-universal-example-A/",
+      "input_dirs": null,
+      "input_files": null,
+      "container_input_dir": "inputs/",
+      "build_commands": [
+        "echo 'hello world'",
+        "touch test.txt"
+      ]
+    },
+    "universal-example-B": {
+      "depends": [
+        "universal-example-A"
+      ],
+      "sdk_url": "golang:latest",
+      "repo_path": "./",
+      "container_output_dirs": null,
+      "container_output_files": [
+        "test.txt"
+      ],
+      "output_dir": "output-universal-example-B/",
+      "input_dirs": null,
+      "input_files": null,
+      "container_input_dir": "inputs/",
+      "build_commands": [
+        "echo 'hello world'",
+        "touch test.txt"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Delete a container in GitHub CI to conserve disk space.

As mentioned in one of the comments, it is not really possible to delete only the specific container. They are somehow embedded into the Dagger Engine (don't know how, possibly in the attached docker volume). So as a workaround we remove the whole Dagger Engine container and it's volume (but keep Dagger Engine image, to not download it again).

This way keep reclaiming disk space, and surprisingly there is not much time-penalty.

Given how it works under the hood, I thought it would be better to avoid automatic enforcement if GitHub CI is detected, and instead as enable this behavior with optional argument.

fixes #560 