### PR TITLE
fix: container cleanup

### DIFF
--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -2,7 +2,11 @@
 # Remove old containers
 
 name: container cleanup
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+    # run weekly
 
 permissions:
   contents: read
@@ -35,6 +39,17 @@ jobs:
       fail-fast: false
       matrix:
         dockerfile: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+        # include discontinued containers
+        include:
+          - dockerfile: 'coreboot_4.20'
+          - dockerfile: 'coreboot_4.22'
+          - dockerfile: 'coreboot_24.02'
+          - dockerfile: 'edk2-stable202408'
+          - dockerfile: 'linux_6.1.111'
+          - dockerfile: 'linux_6.1.45'
+          - dockerfile: 'linux_6.6.52'
+          - dockerfile: 'linux_6.9.9'
+          - dockerfile: 'linux_6.11'
     permissions:
       contents: read
       packages: write
@@ -54,9 +69,8 @@ jobs:
         with:
           package-name: firmware-action/${{ matrix.dockerfile }}
           package-type: container
-          min-versions-to-keep: 5
-          ignore-versions:
-            '^(main|latest|v(\d+\.?)+)$'
+          min-versions-to-keep: 3
+          ignore-versions: '^(main|latest|v(\d+\.?)+)$'
             # ignore:
             # - main
             # - latest

--- a/docs/src/docker/docker-compose.md
+++ b/docs/src/docker/docker-compose.md
@@ -91,3 +91,4 @@ In addition, there might be `VERIFICATION_TEST_*` variables. These are used insi
 
 - Update entry in list of containers in `README.md`
 - Add new regex entry into `Setup()` function in `cmd/firmware-action/container/container.go` to warn about discontinued containers
+- Add the discontinued container to `matrix` `include` in `.github/workflows/container-cleanup.yml` to keep even the discontinued containers tidy


### PR DESCRIPTION
I have not seen or heard any problems related #549, so I think we turn the cleanup on again, but this time as separate workflow (see #536).

- run weekly
- also keep discontinued containers clean

Discontinued containers did get rather messy, for `linux_6.1.45` we had over 30 un-tagged images (not anymore since I ran this manually).

I do see warnings on `coreboot_4.20` and `coreboot_4.22`, but that is because there is no such package / container anymore (I suspect that we switched to `coreboot_4.20.1` and `coreboot_4.22.01` faster than we make releases, and maybe overzealous cleanup removed them? Not sure. But it is only warning on discontinued container, so I don't really care.