### PR TITLE
ci: disable scheduled container-cleanup

### DIFF
--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -4,9 +4,9 @@
 name: container cleanup
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0'
-    # run weekly
+  #schedule:
+  #  - cron: '0 0 * * 0'
+  #  # run weekly
 
 permissions:
   contents: read


### PR DESCRIPTION
- seems like this is what breaks the docker pull
- I have just seen a CI fail when trying to pull `v0.12.0` docker container from GitHub

related to issue #549