### PR TITLE
fix(ci): auto upload

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -34,7 +34,7 @@ jobs:
       # Bump version
       - name: Update action.yml
         run: |
-          sed -i -E "s/version=v[a-zA-Z0-9\.]+/version=${{ steps.semver.outputs.next }}/g" action.yml
+          sed -i -E "s/default: 'v[0-9\.]+'/default: '${{ steps.semver.outputs.next }}'/g" action.yml
 
       # Changelog
       - name: Get cocogitto

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,12 @@ description: |
   Compile a selected firmware solution like coreboot, EDKII, OpenBMC and more
 author: '9elements'
 inputs:
+  version:
+    description: |
+      Version of firmware-action to use. If not specified, latest release will be used.
+      Must be a tag if 'compile' is false, must be a branch is 'compile' is true.
+    required: false
+    default: 'v0.15.0'
   config:
     description: |
       Path to the JSON configuration file.
@@ -115,10 +121,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - id: version
-      shell: bash
-      run: echo "version=v0.15.0" >> "${GITHUB_OUTPUT}"
-
     - id: arch
       # This ARCH is used to fetch correct executable of firmware-action
       # GoReleaser uses 'x86_64' instead of 'amd64'
@@ -163,7 +165,7 @@ runs:
     - id: url
       shell: bash
       run: |
-        echo "url=https://github.com/9elements/firmware-action/releases/download/${{ steps.version.outputs.version }}/${{ steps.filename.outputs.filename }}" >> "${GITHUB_OUTPUT}"
+        echo "url=https://github.com/9elements/firmware-action/releases/download/${{ inputs.version }}/${{ steps.filename.outputs.filename }}" >> "${GITHUB_OUTPUT}"
 
     - name: setup_go
       if: ${{ inputs.compile == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -400,7 +400,7 @@ runs:
             echo "copying ${EXPANDED_DIR}"
             cp -r "${EXPANDED_DIR}" .firmware-action/artifacts/
           fi
-        done < <(jq -r --arg TARGET "${{ inputs.target }}" '[.. | objects | select(has($TARGET)) | .[$TARGET].output_dir? | select(. != null)][]' "${{ steps.merge_config.outputs.merged_config }}")
+        done < <(jq -r --arg TARGET "${{ inputs.target }}" '[.. | objects | select(has($TARGET)) | .[$TARGET].output_dir? | select(. != null)][]' "${{ steps.merge_config.outputs.merged_config }}" | sed -E 's/\/$//g')
         echo "::endgroup::"
 
     - name: save_cache

--- a/action.yml
+++ b/action.yml
@@ -320,6 +320,7 @@ runs:
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_RECURSIVE: ${{ inputs.recursive }}
         INPUT_PRUNE: ${{ inputs.prune }}
+        INPUT_DEBUG: ${{ inputs.debug }}
 
     - name: run_windows
       if: ${{ runner.os == 'Windows' }}
@@ -331,6 +332,7 @@ runs:
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_RECURSIVE: ${{ inputs.recursive }}
         INPUT_PRUNE: ${{ inputs.prune }}
+        INPUT_DEBUG: ${{ inputs.debug }}
 
     #===============
     # CACHE: Create

--- a/action.yml
+++ b/action.yml
@@ -176,23 +176,66 @@ runs:
     #==============================================
     # Acquire firmware-action executable for Linux
     #==============================================
+    # Download from release
     - id: fetch_unix
       if: ${{ ( runner.os == 'Linux' || runner.os == 'macOS' ) && inputs.compile == 'false' }}
       shell: bash
       run: |
-        echo "::group::curl"
+        echo "::group::curl firmware-action"
         curl -L -o "${{ steps.filename.outputs.filename }}" "${{ steps.url.outputs.url }}"
         tar -xvzf "${{ steps.filename.outputs.filename }}"
         chmod +x firmware-action
         echo "::endgroup::"
       # chmod should not be necessary, but just to be safe
+
+    # Compile
+    - name: check_directory
+      if: ${{ inputs.compile == 'true' }}
+      shell: bash
+      id: check_dir
+      run: |
+        if [ -d "./cmd/firmware-action" ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+    # Compile / git clone
+    #   this use-case is when users use firmware-action and want to use compilation to get
+    #   early access to some new features on some experimental branch
+    - name: git_clone_for_compilation
+      if: ${{ inputs.compile == 'true' && steps.check_dir.outputs.exists == 'false' }}
+      shell: bash
+      run: |
+        echo "::group::git clone firmware-action"
+        git clone -n --depth=1 --filter=tree:0 --branch "${{ inputs.version }}" https://github.com/9elements/firmware-action.git ./firmware-action-compile
+        echo "::endgroup::"
+    - name: sparse_checkout
+      if: ${{ inputs.compile == 'true' && steps.check_dir.outputs.exists == 'false' }}
+      shell: bash
+      working-directory: ./firmware-action-compile
+      run: |
+        echo "::group::sparse checkout"
+        git sparse-checkout set --no-cone /cmd
+        git checkout
+        echo "::endgroup::"
+    # Compile / symlink
+    #   this use-case is for firmware-action examples (the source-code is already in the working directory)
+    - name: create_symlink
+      if: ${{ inputs.compile == 'true' && steps.check_dir.outputs.exists == 'true' }}
+      shell: bash
+      run: |
+        echo "::group::create symlink"
+        mkdir -p ./firmware-action-compile/cmd
+        ln -s ../../cmd/firmware-action ./firmware-action-compile/cmd/
+        echo "::endgroup::"
+    # Compile / go build
     - name: compile_unix
       if: ${{ ( runner.os == 'Linux' || runner.os == 'macOS' ) && inputs.compile == 'true' }}
       shell: bash
-      working-directory: ./cmd/firmware-action
+      working-directory: ./firmware-action-compile/cmd/firmware-action
       run: |
         echo "::group::compile firmware-action"
-        go build -ldflags="-s -w" -o ../../firmware-action
+        go build -ldflags="-s -w" -o ../../../firmware-action
         echo "::endgroup::"
 
     #================================================
@@ -207,13 +250,15 @@ runs:
         Invoke-WebRequest -Uri "${{ steps.url.outputs.url }}" -OutFile "${{ steps.filename.outputs.filename }}"
         Expand-Archive -Path "${{ steps.filename.outputs.filename }}" -DestinationPath .\
         echo ##[endgroup]
+    # - name: git_clone_for_compilation
+    # TODO
     - name: compile_windows
       if: ${{ runner.os == 'Windows' && inputs.compile == 'true' }}
       shell: pwsh
       working-directory: ./cmd/firmware-action
       run: |
         echo ##[group]compile firmware-action
-        go build -ldflags="-s -w" -o ../../firmware-action.exe
+        go build -ldflags="-s -w" -o ../../../firmware-action.exe
         echo ##[endgroup]
 
     #================

--- a/action.yml
+++ b/action.yml
@@ -385,24 +385,6 @@ runs:
     # CACHE: Create
     #===============
 
-    - name: copy_artifacts
-      if: ${{ always() && ( inputs.enable-cache == 'true' || inputs.auto-upload-artifacts == 'true' ) }}
-      shell: bash
-      run: |
-        echo "::group::pack"
-        mkdir -p .firmware-action/artifacts/
-
-        # Get output directories from merged config and copy them
-        while IFS= read -r DIR; do
-          # Expand any environment variables in DIR
-          EXPANDED_DIR=$(eval echo "${DIR}")
-          if [ -d "${EXPANDED_DIR}" ]; then
-            echo "copying ${EXPANDED_DIR}"
-            cp -r "${EXPANDED_DIR}" .firmware-action/artifacts/
-          fi
-        done < <(jq -r --arg TARGET "${{ inputs.target }}" '[.. | objects | select(has($TARGET)) | .[$TARGET].output_dir? | select(. != null)][]' "${{ steps.merge_config.outputs.merged_config }}" | sed -E 's/\/$//g')
-        echo "::endgroup::"
-
     - name: save_cache
       if: ${{ always() && inputs.enable-cache == 'true' }}
       uses: actions/cache/save@v4
@@ -419,12 +401,8 @@ runs:
       shell: bash
       id: get_artifact_name
       run: |
-        # Extract output_dir for the specific target from merged config
-        OUTPUT_DIR=$(jq -r --arg TARGET "${{ inputs.target }}" 'to_entries[] | select(.value | to_entries[].key == $TARGET) | .value[$TARGET].output_dir' "${{ steps.merge_config.outputs.merged_config }}" | sed -E 's/\///g')
-        # Expand any environment variables in OUTPUT_DIR
-        OUTPUT_DIR=$(eval echo "${OUTPUT_DIR}")
         DATETIME=$(date "+%Y-%m-%d_%H-%M-%S.%N")
-        echo "artifact_name=artifacts--${{ inputs.target }}--${OUTPUT_DIR}--${DATETIME}" >> "${GITHUB_OUTPUT}"
+        echo "artifact_name=artifacts--${{ inputs.target }}--${DATETIME}" >> "${GITHUB_OUTPUT}"
 
     - name: upload_artifact
       if: ${{ always() && inputs.auto-upload-artifacts == 'true' }}


### PR DESCRIPTION
You can see how this works in [throwaway firmware-action-example PR 30](https://github.com/9elements/firmware-action-example/pull/30), specifically in the `separate jobs` workflow. The mentioned PR should be discard after this one is merged.

So here are few small fixes:
- forgot to pass `debug` from `action.yml` input to `firmware-action` executable
- make compile option work in other CIs (until now this option was only usable in this specific repository, but from now on users can compile and use some cutting edge feature too!)
  - for that to work we needed to add optional input for version (specifies tag or branch)
- fixed handling of artifacts (cache and artifact upload)
- small CI optimizations and fixes