### PR TITLE
ci: optimize when docker containers are build

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -8,14 +8,22 @@ on:
       - '.dagger-ci'
       - '.github/workflows/docker-build-and-test.yml'
       - 'docker/**'
-      - 'tests/**'
+      - 'tests/*.sh'
+      - 'tests/coreboot_*/**'
+      - 'tests/edk2-patches/**'
+      - 'tests/linux_*/**'
+      - 'tests/uboot_*/**'
   push:
     branches: ['main']
     paths:
       - '.dagger-ci'
       - '.github/workflows/docker-build-and-test.yml'
       - 'docker/**'
-      - 'tests/**'
+      - 'tests/*.sh'
+      - 'tests/coreboot_*/**'
+      - 'tests/edk2-patches/**'
+      - 'tests/linux_*/**'
+      - 'tests/uboot_*/**'
   release:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
- the test directory now contains much more files than it did back when the path filter in 'docker-build-and-test.yml' was written
- now it contains even un-related files
- we only need the to concern ourselves with the shell script, as they are self-contained, and some defconfig files