### PR TITLE
refactor(cmd): use T.Chdir for cleaner tests

### DIFF
--- a/cmd/firmware-action/container/container_test.go
+++ b/cmd/firmware-action/container/container_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+//go:build go1.24
+
 // Package container
 package container
 
@@ -147,12 +149,8 @@ func TestSetup(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create test files
-			pwd, err := os.Getwd()
-			defer os.Chdir(pwd) // nolint:errcheck
-			assert.NoError(t, err)
 			tmpDir := t.TempDir()
-			err = os.Chdir(tmpDir)
-			assert.NoError(t, err)
+			t.Chdir(tmpDir)
 
 			// Create InputDirs
 			for _, val := range tc.opts.InputDirs {

--- a/cmd/firmware-action/container/container_test.go
+++ b/cmd/firmware-action/container/container_test.go
@@ -6,7 +6,6 @@
 package container
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,7 +22,7 @@ func TestSetup(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	assert.NoError(t, err)
 	defer client.Close()
@@ -202,7 +201,7 @@ func TestGetArtifacts(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	assert.NoError(t, err)
 	defer client.Close()

--- a/cmd/firmware-action/filesystem/git_test.go
+++ b/cmd/firmware-action/filesystem/git_test.go
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: MIT
+
+//go:build go1.24
+
 package filesystem
 
 import (
@@ -44,15 +47,10 @@ func gitRepoPrepare(t *testing.T, tmpDir string) {
 
 func TestGitRun(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	pwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
-	err = os.Chdir(tmpDir)
-	assert.NoError(t, err)
+	t.Chdir(tmpDir)
 
 	// Test git status ordinary directory (not git repo)
-	_, err = gitRun("./", []string{"git", "status"})
+	_, err := gitRun("./", []string{"git", "status"})
 	assert.ErrorIs(t, err, ErrNotGitRepository)
 
 	gitRepoPrepare(t, tmpDir)
@@ -65,12 +63,7 @@ func TestGitRun(t *testing.T) {
 
 func TestGitDescribeCoreboot(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	pwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
-	err = os.Chdir(tmpDir)
-	assert.NoError(t, err)
+	t.Chdir(tmpDir)
 
 	gitRepoPrepare(t, tmpDir)
 

--- a/cmd/firmware-action/go.mod
+++ b/cmd/firmware-action/go.mod
@@ -1,6 +1,6 @@
 module github.com/9elements/firmware-action/cmd/firmware-action
 
-go 1.23.1
+go 1.24
 
 toolchain go1.24.1
 

--- a/cmd/firmware-action/recipes/coreboot_test.go
+++ b/cmd/firmware-action/recipes/coreboot_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+//go:build go1.24
+
 // Package recipes / coreboot
 package recipes
 
@@ -288,10 +290,8 @@ func TestCorebootBuild(t *testing.T) {
 
 			// Change current working directory
 			pwd, err := os.Getwd()
-			defer os.Chdir(pwd) // nolint:errcheck
 			assert.NoError(t, err)
-			err = os.Chdir(tmpDir)
-			assert.NoError(t, err)
+			t.Chdir(tmpDir)
 
 			// Clone coreboot repo
 			opts := gitCloneOpts{
@@ -572,10 +572,8 @@ func TestCorebootSubmodule(t *testing.T) {
 
 			// Change current working directory
 			pwd, err := os.Getwd()
-			defer os.Chdir(pwd) // nolint:errcheck
 			assert.NoError(t, err)
-			err = os.Chdir(tmpDir)
-			assert.NoError(t, err)
+			t.Chdir(tmpDir)
 
 			// Clone coreboot repo
 			opts := gitCloneOpts{

--- a/cmd/firmware-action/recipes/coreboot_test.go
+++ b/cmd/firmware-action/recipes/coreboot_test.go
@@ -6,7 +6,6 @@
 package recipes
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -274,7 +273,7 @@ func TestCorebootBuild(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()
@@ -554,7 +553,7 @@ func TestCorebootSubmodule(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()

--- a/cmd/firmware-action/recipes/edk2_test.go
+++ b/cmd/firmware-action/recipes/edk2_test.go
@@ -6,7 +6,6 @@
 package recipes
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,7 +50,7 @@ func TestEdk2(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()

--- a/cmd/firmware-action/recipes/edk2_test.go
+++ b/cmd/firmware-action/recipes/edk2_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+//go:build go1.24
+
 // Package recipes / edk2
 package recipes
 
@@ -19,10 +21,6 @@ func TestEdk2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
-
-	pwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
 
 	common := CommonOpts{
 		SdkURL:              "ghcr.io/9elements/firmware-action/edk2-stable202105:main",
@@ -62,15 +60,12 @@ func TestEdk2(t *testing.T) {
 			tmpDir := t.TempDir()
 			tc.edk2Options.RepoPath = filepath.Join(tmpDir, "Edk2")
 
-			// Change current working directory
-			//   create __tmp_files__ directory to store source-code
-			//   mostly useful for repeated local-run tests to save bandwidth and time
+			// Create __tmp_files__ directory to store source-code
+			// mostly useful for repeated local-run tests to save bandwidth and time
 			tmpFiles := filepath.Join(os.TempDir(), "__firmware-action_tmp_files__")
 			err = os.MkdirAll(tmpFiles, 0o750)
 			assert.NoError(t, err)
-			err = os.Chdir(tmpFiles)
-			assert.NoError(t, err)
-			defer os.Chdir(pwd) // nolint:errcheck
+			t.Chdir(tmpFiles)
 
 			// Clone edk2 repo
 			_, err = os.Stat(tc.version)
@@ -84,9 +79,7 @@ func TestEdk2(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Change current working directory
-			err = os.Chdir(tmpDir)
-			assert.NoError(t, err)
-			defer os.Chdir(pwd) // nolint:errcheck
+			t.Chdir(tmpDir)
 
 			// Create "defconfig_path" file
 			err = os.WriteFile(tc.edk2Options.DefconfigPath, []byte("-D BOOTLOADER=COREBOOT"), 0o644)

--- a/cmd/firmware-action/recipes/linux_test.go
+++ b/cmd/firmware-action/recipes/linux_test.go
@@ -6,7 +6,6 @@
 package recipes
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -69,7 +68,7 @@ func TestLinux(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			linuxVersion, err := semver.NewVersion(tc.linuxVersion)
 			assert.NoError(t, err)
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()

--- a/cmd/firmware-action/recipes/recipes_test.go
+++ b/cmd/firmware-action/recipes/recipes_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestExecute(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	assert.NoError(t, err)
 	defer client.Close()
@@ -48,7 +48,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecuteSkipAndMissing(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	assert.NoError(t, err)
 	defer client.Close()
@@ -104,7 +104,7 @@ func executeDummy(_ context.Context, _ string, _ *Config) error {
 }
 
 func TestBuild(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testConfig := Config{
 		Coreboot: map[string]CorebootOpts{

--- a/cmd/firmware-action/recipes/recipes_test.go
+++ b/cmd/firmware-action/recipes/recipes_test.go
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: MIT
+
+//go:build go1.24
+
 package recipes
 
 import (
@@ -51,12 +54,8 @@ func TestExecuteSkipAndMissing(t *testing.T) {
 	defer client.Close()
 
 	// Change current working directory
-	pwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
 	tmpDir := t.TempDir()
-	err = os.Chdir(tmpDir)
-	assert.NoError(t, err)
+	t.Chdir(tmpDir)
 
 	// Create configuration
 	const target = "dummy"

--- a/cmd/firmware-action/recipes/stitching_test.go
+++ b/cmd/firmware-action/recipes/stitching_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+//go:build go1.24
+
 // Package recipes / linux
 package recipes
 
@@ -178,10 +180,6 @@ func TestStitching(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	pwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
-
 	// Define common variables and values
 	baseFileName := "base.img"
 	common := CommonOpts{
@@ -349,8 +347,7 @@ func TestStitching(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Change current working directory
-			assert.NoError(t, os.Chdir(tmpDir)) // just to make sure
-			defer os.Chdir(pwd)                 // nolint:errcheck
+			t.Chdir(tmpDir)
 
 			// Move files
 			for i := range tc.files {

--- a/cmd/firmware-action/recipes/stitching_test.go
+++ b/cmd/firmware-action/recipes/stitching_test.go
@@ -6,7 +6,6 @@
 package recipes
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -356,7 +355,7 @@ func TestStitching(t *testing.T) {
 			}
 
 			// Stitch
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()

--- a/cmd/firmware-action/recipes/uboot_test.go
+++ b/cmd/firmware-action/recipes/uboot_test.go
@@ -6,7 +6,6 @@
 package recipes
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -52,7 +51,7 @@ func TestUBoot(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()

--- a/cmd/firmware-action/recipes/uboot_test.go
+++ b/cmd/firmware-action/recipes/uboot_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+//go:build go1.24
+
 // Package recipes / uboot
 package recipes
 
@@ -24,7 +26,6 @@ func TestUBoot(t *testing.T) {
 
 	pwd, err := os.Getwd()
 	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
 
 	UBootOpts := UBootOpts{
 		CommonOpts: CommonOpts{
@@ -64,11 +65,7 @@ func TestUBoot(t *testing.T) {
 			myUBootOpts.RepoPath = filepath.Join(tmpDir, "u-boot")
 
 			// Change current working directory
-			pwd, err := os.Getwd()
-			defer os.Chdir(pwd) // nolint:errcheck
-			assert.NoError(t, err)
-			err = os.Chdir(tmpDir)
-			assert.NoError(t, err)
+			t.Chdir(tmpDir)
 
 			// Clone coreboot repo
 			cmd := exec.Command("bash", "-c", fmt.Sprintf("git clone https://source.denx.de/u-boot/u-boot.git; cd u-boot; git fetch -a; git checkout v%s", tc.uBootVersion))
@@ -106,5 +103,4 @@ func TestUBoot(t *testing.T) {
 			assert.ErrorIs(t, filesystem.CheckFileExists(filepath.Join(outputPath, "u-boot")), os.ErrExist)
 		})
 	}
-	assert.NoError(t, os.Chdir(pwd)) // just to make sure
 }

--- a/cmd/firmware-action/recipes/universal_test.go
+++ b/cmd/firmware-action/recipes/universal_test.go
@@ -6,7 +6,6 @@
 package recipes
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func TestUniversal(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()

--- a/cmd/firmware-action/recipes/universal_test.go
+++ b/cmd/firmware-action/recipes/universal_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+//go:build go1.24
+
 // Package recipes / universal
 package recipes
 
@@ -19,10 +21,6 @@ func TestUniversal(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
-
-	pwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
 
 	UniversalOpts := UniversalOpts{
 		CommonOpts: CommonOpts{
@@ -60,11 +58,7 @@ func TestUniversal(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Change current working directory
-			pwd, err := os.Getwd()
-			defer os.Chdir(pwd) // nolint:errcheck
-			assert.NoError(t, err)
-			err = os.Chdir(tmpDir)
-			assert.NoError(t, err)
+			t.Chdir(tmpDir)
 
 			// Artifacts
 			outputPath := filepath.Join(tmpDir, myUniversalOpts.OutputDir)
@@ -80,5 +74,4 @@ func TestUniversal(t *testing.T) {
 			assert.ErrorIs(t, filesystem.CheckFileExists(filepath.Join(outputPath, "hello.txt")), os.ErrExist)
 		})
 	}
-	assert.NoError(t, os.Chdir(pwd)) // just to make sure
 }

--- a/cmd/firmware-action/recipes/uroot_test.go
+++ b/cmd/firmware-action/recipes/uroot_test.go
@@ -6,7 +6,6 @@
 package recipes
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -64,7 +63,7 @@ func TestURoot(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 			assert.NoError(t, err)
 			defer client.Close()

--- a/cmd/firmware-action/recipes/uroot_test.go
+++ b/cmd/firmware-action/recipes/uroot_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+//go:build go1.24
+
 // Package recipes / uroot
 package recipes
 
@@ -21,10 +23,6 @@ func TestURoot(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
-
-	pwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(pwd) // nolint:errcheck
 
 	URootOpts := URootOpts{
 		CommonOpts: CommonOpts{
@@ -80,11 +78,7 @@ func TestURoot(t *testing.T) {
 			myURootOpts.RepoPath = filepath.Join(tmpDir, "u-root")
 
 			// Change current working directory
-			pwd, err := os.Getwd()
-			defer os.Chdir(pwd) // nolint:errcheck
-			assert.NoError(t, err)
-			err = os.Chdir(tmpDir)
-			assert.NoError(t, err)
+			t.Chdir(tmpDir)
 
 			// Clone coreboot repo
 			cmd := exec.Command("git", "clone", "--branch", fmt.Sprintf("v%s", tc.uRootVersion), "--depth", "1", "https://github.com/u-root/u-root.git")
@@ -105,5 +99,4 @@ func TestURoot(t *testing.T) {
 			assert.ErrorIs(t, filesystem.CheckFileExists(filepath.Join(outputPath, "initramfs.cpio")), os.ErrExist)
 		})
 	}
-	assert.NoError(t, os.Chdir(pwd)) // just to make sure
 }


### PR DESCRIPTION
- T.Chdir was introduced in new golang v1.24
- it makes test much cleaner

fixes #612 