### PR TITLE
chore(docker): bump golang to v1.24 for u-root

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -309,7 +309,7 @@ services:
     build:
       context: uroot
       args:
-        - GO_VERSION=1.22
+        - GO_VERSION=1.24
         - UROOT_VERSION=0.14.0
   #==================
   # u-boot

--- a/docker/uroot/Dockerfile
+++ b/docker/uroot/Dockerfile
@@ -1,7 +1,7 @@
 # This is multi-stage Dockerfile
 #   Docs: https://docs.docker.com/build/building/multi-stage/
 
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.24
 ARG SOURCE_IMAGE=golang:${GO_VERSION}
 
 #=============


### PR DESCRIPTION
- u-root recently bumped golang version to v1.24
- we are now doing the same
- this should not have any negative effects
- golang should be fully backwards compatible

fixes #666 