### PR TITLE
fix(ci): release merge group checks

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -97,6 +97,7 @@ jobs:
           filters: |
             action:
               - 'cmd/firmware-action/**'
+              - 'action.yml'
       - name: Compile
         id: compile
         # Require compilation if:


### PR DESCRIPTION
- when making a PR for the next release, the merge group checks fail in the example workflow
- they fail because the CURL cannot download the binaries for yet not-existing release
- updating the paths-filter should fix this because when new release is about to happen the action.yml file is always changed because it contains hard-coded version string