### PR TITLE
feat: new u-boot and u-root containers

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -341,6 +341,7 @@ services:
   #==================
   # u-boot
   #==================
+  # Source: https://github.com/u-boot/u-boot
   uboot_2025.01:
     build:
       context: uboot
@@ -352,4 +353,10 @@ services:
       context: uboot
       args:
         - UBOOT_VERSION=2025.04
+        - SOURCE_IMAGE=ubuntu:noble
+  uboot_2025.07:
+    build:
+      context: uboot
+      args:
+        - UBOOT_VERSION=2025.07
         - SOURCE_IMAGE=ubuntu:noble


### PR DESCRIPTION
this should also enable #738 to be merged (together they should fix the failing `u-root` CI test I hope)