### PR TITLE
fix(cmd): universal module build performance

### DIFF
--- a/cmd/firmware-action/recipes/universal.go
+++ b/cmd/firmware-action/recipes/universal.go
@@ -82,17 +82,17 @@ func (opts UniversalOpts) buildFirmware(ctx context.Context, client *dagger.Clie
 
 	// Execute build commands
 	for step := range buildSteps {
-		myContainer, err = myContainer.
-			WithExec(buildSteps[step]).
-			Sync(ctx)
-		if err != nil {
-			slog.Error(
-				"Failed to build universal",
-				slog.Any("error", err),
-			)
+		myContainer = myContainer.WithExec(buildSteps[step])
+	}
 
-			return fmt.Errorf("universal build failed: %w", err)
-		}
+	myContainer, err = myContainer.Sync(ctx)
+	if err != nil {
+		slog.Error(
+			"Failed to build universal",
+			slog.Any("error", err),
+		)
+
+		return fmt.Errorf("universal build failed: %w", err)
 	}
 
 	// Extract artifacts

--- a/cmd/firmware-action/recipes/universal_test.go
+++ b/cmd/firmware-action/recipes/universal_test.go
@@ -6,9 +6,11 @@
 package recipes
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"dagger.io/dagger"
 	"github.com/9elements/firmware-action/cmd/firmware-action/filesystem"
@@ -52,7 +54,10 @@ func TestUniversal(t *testing.T) {
 
 			myUniversalOpts := UniversalOpts
 			myUniversalOpts.SdkURL = "ghcr.io/9elements/firmware-action/coreboot_4.19:main"
-			myUniversalOpts.BuildCommands = []string{"echo 'Hello World!'", "touch hello.txt"}
+
+			cachebusterCmd := fmt.Sprintf("echo %q", time.Now().String())
+			myUniversalOpts.BuildCommands = []string{cachebusterCmd, "echo 'Hello World!'", "touch hello.txt"}
+
 			myUniversalOpts.RepoPath = filepath.Join(tmpDir, "dummy-repo")
 			err = os.Mkdir(myUniversalOpts.RepoPath, 0o755)
 			assert.NoError(t, err)


### PR DESCRIPTION
- users can experience high IO load when having series of IO heavy commands, because after each command is executed, the whole content of the previous step is being copied into a new ephemeral container instead of being reused
- remove the intermediate Sync call to fix this issue

fixes #747 